### PR TITLE
chore: update Rust toolchain

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,6 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        rust: [ 1.71.1 ]
         ic-commit: [ a17247bd86c7aa4e87742bf74d108614580f216d ]
 
     steps:
@@ -31,10 +30,7 @@ jobs:
 
       - name: Install Rust
         run: |
-          rustup update ${{ matrix.rust }} --no-self-update
-          rustup default ${{ matrix.rust }}
-          rustup component add rustfmt
-          rustup component add clippy
+          rustup show
 
       - name: Cache StateMachine
         uses: actions/cache@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,7 +75,7 @@ jobs:
         with:
           ref: ${{ env.TAG }}
       - name: Install Rust
-        run: rustup update 1.71.1 --no-self-update && rustup default 1.71.1
+        run: rustup show
       - id: create-release
         run: gh release create ${{ env.TAG }} --draft --prerelease="true" --title="${{ env.TAG }}" --notes="TBD"
       - name: Install dfx

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,4 @@
 [toolchain]
 channel = "1.71.1"
 targets = ["wasm32-unknown-unknown"]
+components = ["rustfmt", "clippy"]


### PR DESCRIPTION
As recommended by ProdSec we should update the Rust version