### PR TITLE
feat(FI-767) implement deduplication for icrc 1 transfers and send

### DIFF
--- a/cycles-ledger/cycles-ledger.did
+++ b/cycles-ledger/cycles-ledger.did
@@ -95,7 +95,6 @@ type SendErrorReason = variant {
     InvalidReceiver : record {
         receiver : principal;
     };
-
 };
 
 service : {

--- a/cycles-ledger/cycles-ledger.did
+++ b/cycles-ledger/cycles-ledger.did
@@ -95,6 +95,10 @@ type SendErrorReason = variant {
     InvalidReceiver : record {
         receiver : principal;
     };
+    BadBurn : record { 
+        min_burn_amount : nat 
+    };
+
 };
 
 service : {

--- a/cycles-ledger/src/config.rs
+++ b/cycles-ledger/src/config.rs
@@ -6,3 +6,4 @@ pub const TOKEN_NAME: &str = "ICP Cycles";
 pub const TOKEN_SYMBOL: &str = "CYC";
 pub const MAX_MEMO_LENGTH: u32 = 32;
 pub const PERMITTED_DRIFT: Duration = Duration::from_secs(60);
+pub const TRANSACTION_WINDOW: Duration = Duration::from_secs(24 * 60 * 60);

--- a/cycles-ledger/src/endpoints.rs
+++ b/cycles-ledger/src/endpoints.rs
@@ -2,7 +2,7 @@ use candid::{CandidType, Deserialize, Nat, Principal};
 use ic_cdk::api::call::RejectionCode;
 use icrc_ledger_types::icrc1::{
     account::{Account, Subaccount},
-    transfer::{BlockIndex, Memo},
+    transfer::{BlockIndex, Memo, TransferError},
 };
 
 pub type NumCycles = Nat;
@@ -72,4 +72,36 @@ pub enum SendErrorReason {
     InvalidReceiver {
         receiver: Principal,
     },
+    BadBurn {
+        min_burn_amount: Nat,
+    },
+}
+
+impl From<TransferError> for SendErrorReason {
+    fn from(value: TransferError) -> Self {
+        match value {
+            TransferError::BadFee { expected_fee } => SendErrorReason::BadFee { expected_fee },
+            TransferError::BadBurn { min_burn_amount } => {
+                SendErrorReason::BadBurn { min_burn_amount }
+            }
+            TransferError::InsufficientFunds { balance } => {
+                SendErrorReason::InsufficientFunds { balance }
+            }
+            TransferError::TooOld => SendErrorReason::TooOld,
+            TransferError::CreatedInFuture { ledger_time } => {
+                SendErrorReason::CreatedInFuture { ledger_time }
+            }
+            TransferError::TemporarilyUnavailable => SendErrorReason::TemporarilyUnavailable,
+            TransferError::Duplicate { duplicate_of } => {
+                SendErrorReason::Duplicate { duplicate_of }
+            }
+            TransferError::GenericError {
+                error_code,
+                message,
+            } => SendErrorReason::GenericError {
+                error_code,
+                message,
+            },
+        }
+    }
 }

--- a/cycles-ledger/src/main.rs
+++ b/cycles-ledger/src/main.rs
@@ -183,7 +183,7 @@ fn icrc1_transfer(args: TransferArg) -> Result<Nat, TransferError> {
         amount,
         fee: config::FEE,
         memo,
-        created_at_time: args.created_at_time
+        created_at_time: args.created_at_time,
     };
 
     deduplicate(args.created_at_time, operation.hash(), now)?;
@@ -280,7 +280,7 @@ async fn send(args: endpoints::SendArg) -> Result<Nat, SendError> {
         amount,
         fee: config::FEE,
         memo: memo.clone(),
-        created_at_time: args.created_at_time
+        created_at_time: args.created_at_time,
     };
     let now = ic_cdk::api::time();
     deduplicate(args.created_at_time, operation.hash(), now)

--- a/cycles-ledger/src/main.rs
+++ b/cycles-ledger/src/main.rs
@@ -1,7 +1,7 @@
 use candid::{candid_method, Nat};
 use cycles_ledger::endpoints::{SendError, SendErrorReason};
 use cycles_ledger::memo::SendMemo;
-use cycles_ledger::storage::mutate_state;
+use cycles_ledger::storage::{deduplicate, mutate_state, Operation};
 use cycles_ledger::{config, endpoints, storage};
 use ic_cdk::api::call::{msg_cycles_accept128, msg_cycles_available128};
 use ic_cdk::api::management_canister;
@@ -134,8 +134,6 @@ fn icrc1_transfer(args: TransferArg) -> Result<Nat, TransferError> {
     let now = ic_cdk::api::time();
     let balance = storage::balance_of(&from);
 
-    // TODO(FI-767): Implement deduplication.
-
     let amount = match args.amount.0.to_u128() {
         Some(value) => value,
         None => {
@@ -174,16 +172,24 @@ fn icrc1_transfer(args: TransferArg) -> Result<Nat, TransferError> {
             return Err(TransferError::CreatedInFuture { ledger_time: now });
         }
     }
+    let operation = Operation::Transfer {
+        from,
+        to: args.to,
+        amount,
+        fee: config::FEE,
+        memo,
+    };
 
-    let (txid, _hash) = storage::transfer(&from, &args.to, amount, memo, now);
+    deduplicate(args.created_at_time, operation.hash(), now)?;
+    let (txid, _hash) = storage::transfer(operation, now);
 
     Ok(Nat::from(txid))
 }
 
-fn send_emit_error(from: &Account, reason: SendErrorReason) -> Result<Nat, SendError> {
+fn send_error(from: &Account, reason: SendErrorReason) -> SendError {
     let now = ic_cdk::api::time();
     let (fee_block, _fee_hash) = storage::penalize(from, now);
-    Err(SendError { fee_block, reason })
+    SendError { fee_block, reason }
 }
 
 #[update]
@@ -201,10 +207,10 @@ async fn send(args: endpoints::SendArg) -> Result<Nat, SendError> {
         .unwrap_or_default()
     {
         // if it is not an opaque principal ID, the user is trying to send to a non-canister target
-        return send_emit_error(
+        return Err(send_error(
             &from,
             SendErrorReason::InvalidReceiver { receiver: args.to },
-        );
+        ));
     }
     let from_key = storage::to_account_key(&from);
     let balance = storage::balance_of(&from);
@@ -214,48 +220,47 @@ async fn send(args: endpoints::SendArg) -> Result<Nat, SendError> {
     };
 
     // TODO(FI-767): Implement deduplication.
-
     let amount = match args.amount.0.to_u128() {
         Some(value) => value,
         None => {
-            return send_emit_error(
+            return Err(send_error(
                 &from,
                 SendErrorReason::InsufficientFunds {
                     balance: Nat::from(balance),
                 },
-            );
+            ));
         }
     };
     if let Some(fee) = args.fee {
         match fee.0.to_u128() {
             Some(fee) => {
                 if fee != config::FEE {
-                    return send_emit_error(
+                    return Err(send_error(
                         &from,
                         SendErrorReason::BadFee {
                             expected_fee: Nat::from(config::FEE),
                         },
-                    );
+                    ));
                 }
             }
             None => {
-                return send_emit_error(
+                return Err(send_error(
                     &from,
                     SendErrorReason::BadFee {
                         expected_fee: Nat::from(config::FEE),
                     },
-                );
+                ));
             }
         }
     }
     let total_send_cost = amount.saturating_add(config::FEE);
     if total_send_cost > balance {
-        return send_emit_error(
+        return Err(send_error(
             &from,
             SendErrorReason::InsufficientFunds {
                 balance: Nat::from(balance),
             },
-        );
+        ));
     }
     let memo = SendMemo {
         receiver: target_canister.canister_id.as_slice(),
@@ -264,6 +269,16 @@ async fn send(args: endpoints::SendArg) -> Result<Nat, SendError> {
     encoder.encode(memo).expect("Encoding failed");
     let encoded_memo = encoder.into_writer().into();
     let memo = validate_memo(Some(encoded_memo));
+
+    let operation = Operation::Burn {
+        from,
+        amount,
+        fee: config::FEE,
+        memo: memo.clone(),
+    };
+    let now = ic_cdk::api::time();
+    deduplicate(args.created_at_time, operation.hash(), now)
+        .map_err(|err| send_error(&from, err.into()))?;
 
     // While awaiting the deposit call the in-flight cycles shall not be available to the user
     mutate_state(|s| {
@@ -280,15 +295,14 @@ async fn send(args: endpoints::SendArg) -> Result<Nat, SendError> {
     });
 
     if let Err((rejection_code, rejection_reason)) = deposit_cycles_result {
-        send_emit_error(
+        Err(send_error(
             &from,
             SendErrorReason::FailedToSend {
                 rejection_code,
                 rejection_reason,
             },
-        )
+        ))
     } else {
-        let now = ic_cdk::api::time();
         let (send, _send_hash) = storage::send(&from, amount, memo, now);
         Ok(send)
     }

--- a/cycles-ledger/src/main.rs
+++ b/cycles-ledger/src/main.rs
@@ -106,7 +106,7 @@ fn validate_memo(memo: Option<Memo>) -> Option<Memo> {
 fn deposit(arg: endpoints::DepositArg) -> endpoints::DepositResult {
     let cycles_available = msg_cycles_available128();
 
-    // TODO(FI-767): Implement deduplication.
+    // TODO(FI-884): Implement deduplication.
 
     let amount = msg_cycles_accept128(cycles_available);
     if amount <= config::FEE {
@@ -219,7 +219,6 @@ async fn send(args: endpoints::SendArg) -> Result<Nat, SendError> {
         canister_id: args.to,
     };
 
-    // TODO(FI-767): Implement deduplication.
     let amount = match args.amount.0.to_u128() {
         Some(value) => value,
         None => {

--- a/cycles-ledger/src/storage.rs
+++ b/cycles-ledger/src/storage.rs
@@ -261,7 +261,7 @@ pub fn deduplicate(
 ) -> Result<(), DeduplicationError> {
     // TODO: purge old transactions
     if let (Some(created_at_time), tx_hash) = (created_at_timestamp, tx_hash) {
-        // If the created timestamp is outside of the Transaction
+        // If the created timestamp is outside of the permitted Transaction window
         if created_at_time + (config::TRANSACTION_WINDOW.as_nanos() as u64) < now {
             return Err(DeduplicationError::TooOld);
         }

--- a/cycles-ledger/src/storage.rs
+++ b/cycles-ledger/src/storage.rs
@@ -262,7 +262,11 @@ pub fn deduplicate(
     // TODO: purge old transactions
     if let (Some(created_at_time), tx_hash) = (created_at_timestamp, tx_hash) {
         // If the created timestamp is outside of the permitted Transaction window
-        if created_at_time + (config::TRANSACTION_WINDOW.as_nanos() as u64) < now {
+        if created_at_time
+            + (config::TRANSACTION_WINDOW.as_nanos() as u64)
+            + (config::PERMITTED_DRIFT.as_nanos() as u64)
+            < now
+        {
             return Err(DeduplicationError::TooOld);
         }
 

--- a/cycles-ledger/src/storage.rs
+++ b/cycles-ledger/src/storage.rs
@@ -307,7 +307,7 @@ pub fn transfer(operation: Operation, now: u64) -> (u64, Hash) {
             amount,
             fee,
             memo: _,
-            created_at_time:_
+            created_at_time: _,
         } => {
             let from_key = to_account_key(&from);
             let to_key = to_account_key(&to);

--- a/cycles-ledger/src/storage.rs
+++ b/cycles-ledger/src/storage.rs
@@ -283,7 +283,7 @@ pub fn deduplicate(
                     .saturating_add(config::PERMITTED_DRIFT.as_nanos() as u64)
                     < now
                 {
-                    if !mutate_state(|state| state.operations.remove(&tx_hash)).is_some() {
+                    if mutate_state(|state| state.operations.remove(&tx_hash)).is_none() {
                         ic_cdk::trap(&format!("Could not remove tx hash {:?}", tx_hash))
                     }
                 } else {

--- a/cycles-ledger/src/storage.rs
+++ b/cycles-ledger/src/storage.rs
@@ -271,25 +271,9 @@ pub fn deduplicate(
         }
 
         if let Some(block_height) = read_state(|state| state.transactions.get(&tx_hash)) {
-            if let Some(block) = read_state(|state| state.blocks.get(block_height)) {
-                if block
-                    .0
-                    .timestamp
-                    .saturating_add(config::TRANSACTION_WINDOW.as_nanos() as u64)
-                    .saturating_add(config::PERMITTED_DRIFT.as_nanos() as u64)
-                    < now
-                {
-                    if mutate_state(|state| state.transactions.remove(&tx_hash)).is_none() {
-                        ic_cdk::trap(&format!("Could not remove tx hash {:?}", tx_hash))
-                    }
-                } else {
-                    return Err(DeduplicationError::Duplicate {
-                        duplicate_of: Nat::from(block_height),
-                    });
-                }
-            } else {
-                ic_cdk::trap(&format!("Could not find block index {}", block_height))
-            }
+            return Err(DeduplicationError::Duplicate {
+                duplicate_of: Nat::from(block_height),
+            });
         }
     }
     Ok(())

--- a/cycles-ledger/src/storage.rs
+++ b/cycles-ledger/src/storage.rs
@@ -17,7 +17,7 @@ use crate::{ciborium_to_generic_value, compact_account, config, endpoints::Dedup
 const BLOCK_LOG_INDEX_MEMORY_ID: MemoryId = MemoryId::new(1);
 const BLOCK_LOG_DATA_MEMORY_ID: MemoryId = MemoryId::new(2);
 const BALANCES_MEMORY_ID: MemoryId = MemoryId::new(3);
-const TRANSACTIONS_MEMORY_ID: MemoryId = MemoryId::new(4);
+const TRANSACTION_MEMORY_ID: MemoryId = MemoryId::new(4);
 
 type VMem = VirtualMemory<DefaultMemoryImpl>;
 
@@ -166,7 +166,7 @@ thread_local! {
             },
             blocks,
             balances: Balances::init(mm.get(BALANCES_MEMORY_ID)),
-            transactions: TransactionsLog::init(mm.get(TRANSACTIONS_MEMORY_ID)),
+            transactions: TransactionsLog::init(mm.get(TRANSACTION_MEMORY_ID)),
         })
     });
 }

--- a/cycles-ledger/tests/tests.rs
+++ b/cycles-ledger/tests/tests.rs
@@ -228,6 +228,11 @@ fn test_send_flow() {
     );
 
     // send cycles from subaccount with created_at_time set
+    let now = env
+        .time()
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .unwrap()
+        .as_nanos() as u64;
     let send_receiver_balance = env.cycle_balance(send_receiver);
     let send_amount = 300_000_000_u128;
     let _send_idx = send(
@@ -238,7 +243,7 @@ fn test_send_flow() {
             from_subaccount: Some(*user_subaccount_3.effective_subaccount()),
             to: send_receiver,
             fee: None,
-            created_at_time: Some(100_u64),
+            created_at_time: Some(now),
             memo: None,
             amount: Nat::from(send_amount),
         },
@@ -481,7 +486,7 @@ fn test_transfer() {
     let fee = fee(env, ledger_id);
 
     let transfer_amount = Nat::from(100_000);
-    transfer(
+    let idx = transfer(
         env,
         ledger_id,
         user1,
@@ -568,7 +573,9 @@ fn test_transfer() {
         .unwrap_err()
     );
 
-    // Should be able to make a transfer when created time is valid
+    // When making the same transaction again
+    assert_eq!(
+        TransferError::Duplicate { duplicate_of: idx },
     transfer(
         env,
         ledger_id,
@@ -582,5 +589,5 @@ fn test_transfer() {
             amount: transfer_amount.clone(),
         },
     )
-    .unwrap();
+    .unwrap_err());
 }

--- a/cycles-ledger/tests/tests.rs
+++ b/cycles-ledger/tests/tests.rs
@@ -229,10 +229,10 @@ fn test_send_flow() {
 
     // send cycles from subaccount with created_at_time set
     let now = env
-    .time()
-    .duration_since(SystemTime::UNIX_EPOCH)
-    .unwrap()
-    .as_nanos() as u64;
+        .time()
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .unwrap()
+        .as_nanos() as u64;
     let send_receiver_balance = env.cycle_balance(send_receiver);
     let send_amount = 300_000_000_u128;
     let _send_idx = send(
@@ -574,7 +574,7 @@ fn test_transfer() {
     );
 
     // Should be able to make a transfer when created time is valid
-    let tx: Nat= transfer(
+    let tx: Nat = transfer(
         env,
         ledger_id,
         user1,
@@ -591,7 +591,7 @@ fn test_transfer() {
 
     // Should not be able send the same transfer twice if created_at_time is set
     assert_eq!(
-        TransferError::Duplicate { duplicate_of: tx},
+        TransferError::Duplicate { duplicate_of: tx },
         transfer(
             env,
             ledger_id,
@@ -607,7 +607,7 @@ fn test_transfer() {
         )
         .unwrap_err()
     );
-    
+
     // Setting a different memo field should result in no deduplication
     transfer(
         env,
@@ -623,14 +623,14 @@ fn test_transfer() {
         },
     )
     .unwrap();
-    
+
     // Advance time so that the deduplication window is over
-    env.advance_time(config::TRANSACTION_WINDOW*2);
+    env.advance_time(config::TRANSACTION_WINDOW * 2);
     now = env
-    .time()
-    .duration_since(SystemTime::UNIX_EPOCH)
-    .unwrap()
-    .as_nanos() as u64;
+        .time()
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .unwrap()
+        .as_nanos() as u64;
 
     // Now the transfer which was deduplicated previously should be ok
     transfer(
@@ -647,5 +647,4 @@ fn test_transfer() {
         },
     )
     .unwrap();
-
 }

--- a/cycles-ledger/tests/tests.rs
+++ b/cycles-ledger/tests/tests.rs
@@ -1,4 +1,7 @@
-use std::{path::PathBuf, time::SystemTime};
+use std::{
+    path::PathBuf,
+    time::{Duration, SystemTime},
+};
 
 use candid::{Encode, Nat, Principal};
 use client::{deposit, transfer};
@@ -625,7 +628,7 @@ fn test_transfer() {
     .unwrap();
 
     // Advance time so that the deduplication window is over
-    env.advance_time(config::TRANSACTION_WINDOW * 2);
+    env.advance_time(Duration::from_secs(1));
     now = env
         .time()
         .duration_since(SystemTime::UNIX_EPOCH)

--- a/cycles-ledger/tests/tests.rs
+++ b/cycles-ledger/tests/tests.rs
@@ -576,7 +576,7 @@ fn test_transfer() {
         .unwrap_err()
     );
 
-    // Should be able to make a transfer when created_at_ time is valid
+    // Should be able to make a transfer when created_at_time is valid
     let tx: Nat = transfer(
         env,
         ledger_id,

--- a/cycles-ledger/tests/tests.rs
+++ b/cycles-ledger/tests/tests.rs
@@ -627,7 +627,7 @@ fn test_transfer() {
     )
     .unwrap();
 
-    // Advance time so that the deduplication window is over
+    // Advance time so that the deduplication window is shifted
     env.advance_time(Duration::from_secs(1));
     now = env
         .time()

--- a/cycles-ledger/tests/tests.rs
+++ b/cycles-ledger/tests/tests.rs
@@ -573,7 +573,7 @@ fn test_transfer() {
         .unwrap_err()
     );
 
-    // Should be able to make a transfer when created time is valid
+    // Should be able to make a transfer when created_at_ time is valid
     let tx: Nat = transfer(
         env,
         ledger_id,


### PR DESCRIPTION
This MR introduces the following changes:

1. Add deduplication method according to the [ICRC-1 standard](https://github.com/dfinity/ICRC-1/blob/main/standards/ICRC-1/README.md)
2. Add deduplication to icrc1 transfer
3. Add deduplication to send
5. Add tests for the deduplication method
6. Add transaction log to store transactions by hash
7. Add transaction window