### PR TITLE
feat: remove penalize from send validation errors

### DIFF
--- a/cycles-ledger/cycles-ledger.did
+++ b/cycles-ledger/cycles-ledger.did
@@ -43,11 +43,11 @@ type SendArgs = record {
     to : principal;
     created_at_time : opt nat64;
 };
-type SendError = record { fee_block : opt nat; reason : SendErrorReason };
-type SendErrorReason = variant {
+type SendError = variant {
   GenericError : record { message : text; error_code : nat };
   TemporarilyUnavailable;
   FailedToSend : record {
+    fee_block : opt nat;
     rejection_code : RejectionCode;
     rejection_reason : text;
   };

--- a/cycles-ledger/src/endpoints.rs
+++ b/cycles-ledger/src/endpoints.rs
@@ -42,13 +42,7 @@ pub struct SendArgs {
 }
 
 #[derive(CandidType, Deserialize, Clone, Debug, PartialEq, Eq)]
-pub struct SendError {
-    pub fee_block: Option<Nat>,
-    pub reason: SendErrorReason,
-}
-
-#[derive(CandidType, Deserialize, Clone, Debug, PartialEq, Eq)]
-pub enum SendErrorReason {
+pub enum SendError {
     BadFee {
         expected_fee: NumCycles,
     },
@@ -64,6 +58,7 @@ pub enum SendErrorReason {
         duplicate_of: BlockIndex,
     },
     FailedToSend {
+        fee_block: Option<Nat>,
         rejection_code: RejectionCode,
         rejection_reason: String,
     },
@@ -82,16 +77,14 @@ pub enum DeduplicationError {
     Duplicate { duplicate_of: BlockIndex },
 }
 
-impl From<DeduplicationError> for SendErrorReason {
+impl From<DeduplicationError> for SendError {
     fn from(value: DeduplicationError) -> Self {
         match value {
-            DeduplicationError::TooOld => SendErrorReason::TooOld,
+            DeduplicationError::TooOld => SendError::TooOld,
             DeduplicationError::CreatedInFuture { ledger_time } => {
-                SendErrorReason::CreatedInFuture { ledger_time }
+                SendError::CreatedInFuture { ledger_time }
             }
-            DeduplicationError::Duplicate { duplicate_of } => {
-                SendErrorReason::Duplicate { duplicate_of }
-            }
+            DeduplicationError::Duplicate { duplicate_of } => SendError::Duplicate { duplicate_of },
         }
     }
 }

--- a/cycles-ledger/src/main.rs
+++ b/cycles-ledger/src/main.rs
@@ -1,6 +1,6 @@
 use candid::{candid_method, Nat};
 use cycles_ledger::endpoints::{
-    DeduplicationError, GetTransactionsArgs, GetTransactionsResult, SendError, SendErrorReason,
+    DeduplicationError, GetTransactionsArgs, GetTransactionsResult, SendError,
 };
 use cycles_ledger::logs::{Log, LogEntry, Priority};
 use cycles_ledger::logs::{P0, P1};
@@ -289,12 +289,6 @@ fn icrc3_get_transactions(args: GetTransactionsArgs) -> GetTransactionsResult {
     storage::get_transactions(args)
 }
 
-fn send_error(from: &Account, reason: SendErrorReason) -> SendError {
-    let now = ic_cdk::api::time();
-    let fee_block = storage::penalize(from, now).map(|(fee_block, _block_hash)| fee_block);
-    SendError { fee_block, reason }
-}
-
 #[update]
 #[candid_method]
 async fn send(args: endpoints::SendArgs) -> Result<Nat, SendError> {
@@ -310,10 +304,7 @@ async fn send(args: endpoints::SendArgs) -> Result<Nat, SendError> {
         .unwrap_or_default()
     {
         // if it is not an opaque principal ID, the user is trying to send to a non-canister target
-        return Err(send_error(
-            &from,
-            SendErrorReason::InvalidReceiver { receiver: args.to },
-        ));
+        return Err(SendError::InvalidReceiver { receiver: args.to });
     }
     let from_key = storage::to_account_key(&from);
     let balance = storage::balance_of(&from);
@@ -325,23 +316,17 @@ async fn send(args: endpoints::SendArgs) -> Result<Nat, SendError> {
     let amount = match args.amount.0.to_u128() {
         Some(value) => value,
         None => {
-            return Err(send_error(
-                &from,
-                SendErrorReason::InsufficientFunds {
-                    balance: Nat::from(balance),
-                },
-            ));
+            return Err(SendError::InsufficientFunds {
+                balance: Nat::from(balance),
+            });
         }
     };
 
     let total_send_cost = amount.saturating_add(config::FEE);
     if total_send_cost > balance {
-        return Err(send_error(
-            &from,
-            SendErrorReason::InsufficientFunds {
-                balance: Nat::from(balance),
-            },
-        ));
+        return Err(SendError::InsufficientFunds {
+            balance: Nat::from(balance),
+        });
     }
     let memo = validate_memo(Some(encode_send_memo(&target_canister.canister_id)));
 
@@ -352,8 +337,7 @@ async fn send(args: endpoints::SendArgs) -> Result<Nat, SendError> {
     };
 
     let now = ic_cdk::api::time();
-    deduplicate(args.created_at_time, transaction.hash(), now)
-        .map_err(|err| send_error(&from, err.into()))?;
+    deduplicate(args.created_at_time, transaction.hash(), now)?;
 
     // While awaiting the deposit call the in-flight cycles shall not be available to the user
     mutate_state(now, |s| s.debit(from_key, total_send_cost));
@@ -363,13 +347,13 @@ async fn send(args: endpoints::SendArgs) -> Result<Nat, SendError> {
     mutate_state(now, |s| s.credit(from_key, total_send_cost));
 
     if let Err((rejection_code, rejection_reason)) = deposit_cycles_result {
-        Err(send_error(
-            &from,
-            SendErrorReason::FailedToSend {
-                rejection_code,
-                rejection_reason,
-            },
-        ))
+        let now = ic_cdk::api::time();
+        let fee_block = storage::penalize(&from, now).map(|(fee_block, _block_hash)| fee_block);
+        Err(SendError::FailedToSend {
+            fee_block,
+            rejection_code,
+            rejection_reason,
+        })
     } else {
         let (send, _send_hash) = storage::send(&from, amount, memo, now, args.created_at_time);
         Ok(send)


### PR DESCRIPTION
1. remove penalization (pay the fee) for send validation errors. The penalization happens only if a call to the management canister is done.
2. refactor `SendError` so that the fee is only in `FailedToSend`. The fee is still optional and it's set only in case the balance of the user is > FEE and the Ledger was able to create the burn block.