### PR TITLE
feat: add test that checks that upgrading the ledger preserves the state

### DIFF
--- a/cycles-ledger/cycles-ledger.did
+++ b/cycles-ledger/cycles-ledger.did
@@ -87,7 +87,7 @@ type TransferFromArgs = record {
   amount : nat;
 };
 type TransferFromError = variant {
-  GenericError : record { message : text; error_code : na };
+  GenericError : record { message : text; error_code : nat };
   TemporarilyUnavailable;
   InsufficientAllowance : record { allowance : nat };
   BadBurn : record { min_burn_amount : nat };

--- a/cycles-ledger/cycles-ledger.did
+++ b/cycles-ledger/cycles-ledger.did
@@ -87,7 +87,7 @@ type TransferFromArgs = record {
   amount : nat;
 };
 type TransferFromError = variant {
-  GenericError : record { message : text; error_code : nat };
+  GenericError : record { message : text; error_code : na };
   TemporarilyUnavailable;
   InsufficientAllowance : record { allowance : nat };
   BadBurn : record { min_burn_amount : nat };

--- a/cycles-ledger/tests/gen.rs
+++ b/cycles-ledger/tests/gen.rs
@@ -677,7 +677,7 @@ pub fn arb_cycles_ledger_call_state(
     )
 }
 
-// Note(mp): this genereator will blow up the stack for high `len`
+// Note: this genereator will blow up the stack for high `len`
 // because it will call itself recursively `len` times. If you need a bigger
 // state then do multiple sequential calls to
 // [arb_cycles_ledger_call_state_from].

--- a/cycles-ledger/tests/gen.rs
+++ b/cycles-ledger/tests/gen.rs
@@ -179,7 +179,7 @@ where
     }
 }
 
-// A cycles-ledger and depositor cannisters installed on a [StateMachine].
+// A cycles ledger and a depositor canister installed on a [StateMachine].
 #[derive(Clone)]
 pub struct CyclesLedgerInStateMachine<'a> {
     pub env: &'a StateMachine,

--- a/cycles-ledger/tests/gen.rs
+++ b/cycles-ledger/tests/gen.rs
@@ -200,7 +200,7 @@ impl<'a> CyclesLedgerApplyCall for CyclesLedgerInStateMachine<'a> {
                     "icrc2_approve",
                     arg,
                 )?
-                .map_err(|e|
+                .map_err(|e| {
                     format!(
                         "call to approve(from:{}, spender:{}, amount:{}) failed: {:?}",
                         Account {
@@ -211,13 +211,17 @@ impl<'a> CyclesLedgerApplyCall for CyclesLedgerInStateMachine<'a> {
                         arg.amount,
                         e,
                     )
-                )?;
+                })?;
             }
             Send(arg) => {
                 let _ = update_call::<_, Result<Nat, SendError>>(
-                    self.env, self.ledger_id, call.caller, "send", arg,
+                    self.env,
+                    self.ledger_id,
+                    call.caller,
+                    "send",
+                    arg,
                 )?
-                .map_err(|e|
+                .map_err(|e| {
                     format!(
                         "call to send(from:{}, to:{}, amount:{}) failed: {:?}",
                         Account {
@@ -228,7 +232,7 @@ impl<'a> CyclesLedgerApplyCall for CyclesLedgerInStateMachine<'a> {
                         arg.amount,
                         e,
                     )
-                )?;
+                })?;
             }
             Transfer(arg) => {
                 let _ = update_call::<_, Result<Nat, TransferError>>(
@@ -238,7 +242,7 @@ impl<'a> CyclesLedgerApplyCall for CyclesLedgerInStateMachine<'a> {
                     "icrc1_transfer",
                     arg,
                 )?
-                .map_err(|e|
+                .map_err(|e| {
                     format!(
                         "call to icrc1_transfer(from:{}, to:{}, amount:{}) failed: {}",
                         Account {
@@ -249,7 +253,7 @@ impl<'a> CyclesLedgerApplyCall for CyclesLedgerInStateMachine<'a> {
                         arg.amount,
                         e,
                     )
-                )?;
+                })?;
             }
             TransferFrom(arg) => {
                 let _ = update_call::<_, Result<Nat, TransferError>>(
@@ -270,10 +274,7 @@ impl<'a> CyclesLedgerApplyCall for CyclesLedgerInStateMachine<'a> {
                 )?;
             }
             Deposit { amount, arg } => {
-                let cycles = amount
-                    .0
-                    .to_u128()
-                    .unwrap();
+                let cycles = amount.0.to_u128().unwrap();
                 let arg = depositor::endpoints::DepositArg {
                     to: arg.to.to_owned(),
                     memo: arg.memo.to_owned(),
@@ -358,7 +359,7 @@ impl CyclesLedgerApplyCall for CyclesLedgerInMemory {
                     .depositor_cycles
                     .saturating_sub(10_000_000_000_000u128.saturating_add(amount));
 
-                let old_balance = self.balances.get(&to).copied().unwrap_or_default();
+                let old_balance = self.balances.get(to).copied().unwrap_or_default();
                 self.balances
                     .insert(*to, old_balance.checked_add(amount).ok_or("overflow")?);
                 self.total_supply = self
@@ -412,7 +413,7 @@ impl CyclesLedgerApplyCall for CyclesLedgerInMemory {
                     .and_then(|b| b.checked_sub(FEE))
                     .ok_or("balance underflow")?;
                 self.balances.insert(from, new_balance);
-                let old_balance = self.balances.get(&to).copied().unwrap_or_default();
+                let old_balance = self.balances.get(to).copied().unwrap_or_default();
                 self.balances.insert(
                     *to,
                     old_balance.checked_add(amount).ok_or("balance overflow")?,
@@ -478,7 +479,6 @@ impl CyclesLedgerCallsState {
             state: CyclesLedgerInMemory::new(depositor_cycles),
         }
     }
-
 
     // Return the number of tokens available for minting
     fn token_pool(&self) -> u128 {

--- a/cycles-ledger/tests/gen.rs
+++ b/cycles-ledger/tests/gen.rs
@@ -677,7 +677,7 @@ pub fn arb_cycles_ledger_call_state(
     )
 }
 
-// Note: this genereator will blow up the stack for high `len`
+// Note: this generator will blow up the stack for high `len`
 // because it will call itself recursively `len` times. If you need a bigger
 // state then do multiple sequential calls to
 // [arb_cycles_ledger_call_state_from].

--- a/cycles-ledger/tests/gen.rs
+++ b/cycles-ledger/tests/gen.rs
@@ -577,7 +577,7 @@ fn arb_approve(
 prop_compose! {
     fn arb_deposit(depositor: Principal, depositor_cycles: u128)
                   (to in arb_account(),
-                  // deposit requires that the amount >= FEE
+                  // deposit requires that the amount is >= FEE
                    amount in arb_amount(depositor_cycles - FEE).prop_map(|c| c + Nat::from(FEE)),
                    memo in option::of(arb_memo()),
                   )

--- a/cycles-ledger/tests/gen.rs
+++ b/cycles-ledger/tests/gen.rs
@@ -590,7 +590,7 @@ prop_compose! {
 }
 
 prop_compose! {
-    fn arb_send(arb_from: impl Strategy<Value = (Account, u128)>, depositor: Principal)
+    fn arb_withdraw(arb_from: impl Strategy<Value = (Account, u128)>, depositor: Principal)
                ((from, from_balance) in arb_from)
                (from in Just(from),
                 amount in (0..=(from_balance - FEE)).prop_map(Nat::from),
@@ -714,8 +714,8 @@ pub fn arb_cycles_ledger_call_state_from(
             arb_calls.push(arb_approve.boxed());
 
             // send
-            let arb_send = arb_send(select_account_and_balance.clone(), depositor);
-            arb_calls.push(arb_send.boxed());
+            let arb_withdraw = arb_withdraw(select_account_and_balance.clone(), depositor);
+            arb_calls.push(arb_withdraw.boxed());
 
             // transfer
             let arb_transfer = arb_transfer(select_account_and_balance);

--- a/cycles-ledger/tests/gen.rs
+++ b/cycles-ledger/tests/gen.rs
@@ -1,0 +1,416 @@
+use std::{collections::HashMap, sync::Arc};
+
+use candid::{Principal, Nat};
+use cycles_ledger::{storage::Block, endpoints::{SendArgs, DepositArg}, config::FEE};
+use icrc_ledger_types::{icrc1::{account::Account, transfer::{TransferArg, Memo}}, icrc2::{approve::ApproveArgs, transfer_from::TransferFromArgs}};
+use num_traits::ToPrimitive;
+use proptest::{strategy::{Strategy, Just, Union}, prop_compose, prelude::any, option, collection, proptest, prop_assert_eq, sample::select};
+use serde_bytes::ByteBuf;
+
+#[derive(Clone, Debug)]
+pub enum CyclesLedgerCallArg {
+    Approve(ApproveArgs),
+    Deposit {
+        amount: Nat,
+        arg: DepositArg,
+    },
+    Send(SendArgs),
+    Transfer(TransferArg),
+    TransferFrom(TransferFromArgs),
+}
+
+impl From<ApproveArgs> for CyclesLedgerCallArg {
+    fn from(value: ApproveArgs) -> Self {
+        Self::Approve(value)
+    }
+}
+
+impl From<(Nat, DepositArg)> for CyclesLedgerCallArg {
+    fn from((amount, arg): (Nat, DepositArg)) -> Self {
+        Self::Deposit { amount, arg }
+    }
+}
+
+impl From<SendArgs> for CyclesLedgerCallArg {
+    fn from(value: SendArgs) -> Self {
+        Self::Send(value)
+    }
+}
+
+impl From<TransferArg> for CyclesLedgerCallArg {
+    fn from(value: TransferArg) -> Self {
+        Self::Transfer(value)
+    }
+}
+
+impl From<TransferFromArgs> for CyclesLedgerCallArg {
+    fn from(value: TransferFromArgs) -> Self {
+        Self::TransferFrom(value)
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct CyclesLedgerCall {
+    caller: Principal,
+    arg: CyclesLedgerCallArg,
+}
+
+impl From<Block> for CyclesLedgerCall {
+    fn from(block: Block) -> Self {
+        use cycles_ledger::storage::Operation::*;
+
+        match block.transaction.operation {
+            Mint { to, amount } =>
+                CyclesLedgerCall {
+                    // random bc the depositor is not persisted
+                    caller: Principal::from_slice(&[123]),
+                    arg: CyclesLedgerCallArg::Deposit {
+                        amount: Nat::from(amount),
+                        arg: DepositArg { to, memo: block.transaction.memo }
+                    }
+                },
+            Transfer { from, to, spender: Some(spender), amount, fee } =>
+                CyclesLedgerCall {
+                    caller: spender.owner,
+                    arg: CyclesLedgerCallArg::TransferFrom(TransferFromArgs {
+                        spender_subaccount: spender.subaccount,
+                        from,
+                        to,
+                        created_at_time: block.transaction.created_at_time,
+                        memo: block.transaction.memo,
+                        amount: Nat::from(amount),
+                        fee: fee.map(Nat::from),
+                    })
+                },
+            Transfer { from, to, spender: _, amount, fee } =>
+                CyclesLedgerCall {
+                    caller: from.owner,
+                    arg: CyclesLedgerCallArg::Transfer(TransferArg {
+                        from_subaccount: from.subaccount,
+                        to,
+                        created_at_time: block.transaction.created_at_time,
+                        memo: block.transaction.memo,
+                        amount: Nat::from(amount),
+                        fee: fee.map(Nat::from),
+                    })
+                },
+            Burn { from, amount } =>
+                CyclesLedgerCall {
+                    caller: from.owner,
+                    arg: CyclesLedgerCallArg::Send(SendArgs { 
+                        from_subaccount: from.subaccount,
+                        to: Principal::from_slice(block.transaction.memo
+                            .expect("Memo should be set in send block")
+                            .0.as_slice()),
+                        created_at_time: block.transaction.created_at_time,
+                        amount: Nat::from(amount),
+                    })
+                },
+            Approve { from, spender, amount, expected_allowance, expires_at, fee } =>
+                CyclesLedgerCall {
+                    caller: from.owner,
+                    arg: CyclesLedgerCallArg::Approve(ApproveArgs {
+                        from_subaccount: from.subaccount,
+                        spender,
+                        amount: Nat::from(amount),
+                        expected_allowance: expected_allowance.map(Nat::from),
+                        expires_at,
+                        fee: fee.map(Nat::from),
+                        memo: block.transaction.memo,
+                        created_at_time: block.transaction.created_at_time,
+                    }),
+                },
+        }
+    }
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct CyclesLedgerState {
+    pub balances: HashMap<Account, u128>,
+    pub allowances: HashMap<(Account, Account), u128>,
+    pub token_supply: u128,
+}
+
+impl CyclesLedgerState {
+    fn token_pool(&self) -> u128 {
+        u128::MAX - self.token_supply
+    }
+
+    fn apply(&mut self, arg: CyclesLedgerCall) {
+        match arg.arg {
+            CyclesLedgerCallArg::Approve(ApproveArgs { from_subaccount, spender, amount, .. }) => {
+                let from = Account { owner: arg.caller, subaccount: from_subaccount };
+                let old_balance = self.balances.get(&from)
+                    .unwrap_or_else(|| panic!("Account {} has 0 balance", from));
+                self.balances.insert(from, old_balance - FEE);
+                self.allowances.insert((from, spender), amount.0.to_u128().unwrap());
+            },
+            CyclesLedgerCallArg::Deposit { amount, arg: DepositArg { to, .. } } => {
+                let old_balance = self.balances.get(&to).map(|b| *b).unwrap_or_default();
+                self.balances.insert(to, old_balance + amount.0.to_u128().unwrap());
+            },
+            CyclesLedgerCallArg::Send(SendArgs { from_subaccount, amount, .. }) => {
+                let from = Account { owner: arg.caller, subaccount: from_subaccount };
+                let old_balance = self.balances.get(&from)
+                    .unwrap_or_else(|| panic!("Account {} has 0 balance", from));
+                self.balances.insert(from, old_balance - amount.0.to_u128().unwrap());
+            },
+            CyclesLedgerCallArg::Transfer(TransferArg { from_subaccount, to, amount, .. }) => {
+                let from = Account { owner: arg.caller, subaccount: from_subaccount };
+                let old_balance = self.balances.get(&from)
+                    .unwrap_or_else(|| panic!("Account {} has 0 balance", from));
+                let amount = amount.0.to_u128().unwrap();
+                self.balances.insert(from, old_balance - amount - FEE);
+                let old_balance = self.balances.get(&to).map(|b| *b).unwrap_or_default();
+                self.balances.insert(to, old_balance + amount);
+            },
+            CyclesLedgerCallArg::TransferFrom(TransferFromArgs { spender_subaccount, from, to, amount, fee, memo, created_at_time  }) => {
+                self.apply(CyclesLedgerCall {
+                    caller: from.owner,
+                    arg: CyclesLedgerCallArg::Transfer(TransferArg {
+                        from_subaccount: from.subaccount,
+                        to,
+                        fee,
+                        created_at_time,
+                        memo,
+                        amount: amount.clone(),
+                    }),
+                });
+                let spender = Account { owner: arg.caller, subaccount: spender_subaccount };
+                let allowance = self.allowances.get(&(from, spender))
+                    .unwrap_or_else(||panic!("Allowance of {:?} is 0", (from, spender)));
+                self.allowances.insert((from, spender), allowance - amount.0.to_u128().unwrap());
+            },
+        }
+    }
+}
+
+// Represent a set of valid calls and the
+// state that results from performing those
+// calls on the state
+#[derive(Clone, Debug, Default)]
+pub struct CyclesLedgerCallsState {
+    pub calls: Vec<CyclesLedgerCall>,
+    pub state: CyclesLedgerState,
+}
+
+impl CyclesLedgerCallsState {
+    fn apply(&mut self, arg: CyclesLedgerCall) {
+        self.state.apply(arg.clone());
+        self.calls.push(arg);
+    }
+
+    // Return the number of tokens available for minting
+    fn token_pool(&self) -> u128 {
+        self.state.token_pool()
+    }
+
+    fn accounts_with_at_least_fee(&self) -> Vec<(Account, u128)> {
+        self.state.balances.iter().filter_map(|(account, balance)|
+            if balance >= &FEE { Some((*account, *balance)) } else { None })
+            .collect()
+    }
+}
+
+fn arb_allowed_principal() -> impl Strategy<Value = Principal> {
+    collection::vec(any::<u8>(), 0..30)
+        .prop_filter_map("Management and anonimous principals are disabled", |bytes| {
+            let principal = Principal::from_slice(&bytes);
+            if principal == Principal::management_canister() ||
+               principal == Principal::anonymous() {
+                None
+            } else {
+                Some(principal)
+            }
+        })
+}
+
+fn arb_account() -> impl Strategy<Value = Account> {
+    (arb_allowed_principal(), option::of(any::<[u8;32]>()))
+        .prop_map(|(owner, subaccount)| Account { owner, subaccount })
+}
+
+fn arb_amount(max: u128) -> impl Strategy<Value = Nat> {
+    (0..=max).prop_map(Nat::from)
+}
+
+fn arb_memo() -> impl Strategy<Value = Memo> {
+    collection::vec(any::<u8>(), 0..32)
+        .prop_map(|bytes| Memo(ByteBuf::from(bytes)))
+}
+
+fn arb_approve(token_pool: u128,
+               allowances: Arc<HashMap<(Account, Account), u128>>,
+               arb_approver: impl Strategy<Value = Account>)
+               -> impl Strategy<Value = CyclesLedgerCall> {
+    (arb_approver, arb_account(), arb_amount(token_pool))
+        .prop_filter("self-approve disabled", |(approver, spender, _)| approver != spender )
+        .prop_flat_map(
+            move |(approver, spender, amount)| {
+                let allowance = allowances.get(&(approver, spender)).map(|b| *b).unwrap_or_default();
+                let arb_expected_allowance = option::of(Just(allowance.into()));
+                let arb_suggested_fee = option::of(Just(FEE.into()));
+                (option::of(arb_memo()), arb_expected_allowance, arb_suggested_fee).prop_map(
+                    move |(memo, expected_allowance, fee)|
+                        CyclesLedgerCall {
+                            caller: approver.owner,
+                            arg: ApproveArgs {
+                                from_subaccount: approver.subaccount,
+                                spender,
+                                amount: amount.clone(),
+                                expected_allowance,
+                                expires_at: None, // TODO
+                                fee,
+                                memo,
+                                created_at_time: None, // TODO
+                            }.into()
+                        }
+                )
+            }
+    )
+}
+
+prop_compose! {
+    fn arb_deposit(token_pool: u128, depositor: Principal)
+                  (to in arb_account(),
+                   amount in arb_amount(token_pool),
+                   memo in option::of(arb_memo()),
+                  )
+                  -> CyclesLedgerCall {
+        CyclesLedgerCall {
+            caller: depositor,
+            arg: (amount, DepositArg { to, memo, }).into()
+        }
+    }
+}
+
+prop_compose! {
+    fn arb_send(arb_from: impl Strategy<Value = (Account, u128)>)
+               ((from, from_balance) in arb_from)
+               (from in Just(from),
+                to in arb_allowed_principal(),
+                amount in (0..=from_balance).prop_map(Nat::from),
+               )
+               -> CyclesLedgerCall {
+        let amount = Nat::from(amount);
+        CyclesLedgerCall {
+            caller: from.owner,
+            arg: SendArgs {
+                from_subaccount: from.subaccount,
+                to,
+                created_at_time: None, // TODO
+                amount
+            }.into(),
+        }
+    }
+}
+
+prop_compose! {
+    fn arb_transfer(arb_from: impl Strategy<Value = (Account, u128)>)
+                   ((from, from_balance) in arb_from)
+                   (from in Just(from),
+                    to in arb_account().prop_filter("cannot self tranasfer", move |to| &from != to),
+                    fee in option::of(Just(FEE.into())),
+                    amount in (0..=from_balance).prop_map(Nat::from),
+                    memo in option::of(arb_memo()),
+                   )
+                   -> CyclesLedgerCall {
+        CyclesLedgerCall {
+            caller: from.owner,
+            arg: TransferArg {
+                from_subaccount: from.subaccount,
+                to,
+                fee,
+                created_at_time: None,
+                memo,
+                amount
+            }.into(),
+        }
+    }
+}
+
+prop_compose! {
+    fn arb_transfer_from(arb_from_spender: impl Strategy<Value = (Account, Account, u128)>)
+                        ((from, spender, from_balance) in arb_from_spender)
+                        (from in Just(from),
+                         spender in Just(spender),
+                         to in arb_account().prop_filter("cannot self tranasfer", move |to| &from != to),
+                         fee in option::of(Just(FEE.into())),
+                         amount in (0..=from_balance).prop_map(Nat::from),
+                         memo in option::of(arb_memo()),
+                        )
+                        -> CyclesLedgerCall {
+        CyclesLedgerCall {
+            caller: spender.owner,
+            arg: TransferFromArgs {
+                from,
+                to,
+                spender_subaccount: spender.subaccount,
+                fee,
+                created_at_time: None,
+                memo,
+                amount,
+            }.into(),
+        }
+    }
+}
+
+pub fn arb_cycles_ledger_call_state(depositor: Principal, len: u8) -> impl Strategy<Value = CyclesLedgerCallsState> {
+    fn step(state: CyclesLedgerCallsState, depositor: Principal, n: u8) -> impl Strategy<Value = CyclesLedgerCallsState> {
+        if n == 0 {
+            return Just(state).boxed();
+        }
+
+        let accounts = state.accounts_with_at_least_fee();
+        let token_pool = state.token_pool();
+        let allowances = Arc::new(state.state.allowances.clone());
+
+        let mut arb_calls = vec![
+            arb_deposit(token_pool, depositor).boxed()  
+        ];
+        if !accounts.is_empty() {
+            let select_account_and_balance = Arc::new(select(accounts.clone()));
+
+            // approve
+            let select_account = select_account_and_balance.clone().prop_map(|(a, _)| a);
+            let arb_approve = arb_approve(token_pool, allowances.clone(), select_account);
+            arb_calls.push(arb_approve.boxed());
+
+            // send
+            let arb_send = arb_send(select_account_and_balance.clone());
+            arb_calls.push(arb_send.boxed());
+
+            // transfer
+            let arb_transfer = arb_transfer(select_account_and_balance);
+            arb_calls.push(arb_transfer.boxed());
+
+            // transfer_from
+            let accounts: HashMap<_, _> = accounts.iter().map(|a| a.clone()).collect();
+            let mut from_spender_amount = vec![];
+            for ((from, spender), allowance) in allowances.as_ref() {
+                let Some(balance) = accounts.get(&from) else { continue; };
+                from_spender_amount.push((*from, *spender, *allowance.min(balance)));
+            }
+            if !from_spender_amount.is_empty() {
+                let arb_transfer_from = arb_transfer_from(select(from_spender_amount));
+                arb_calls.push(arb_transfer_from.boxed());
+            }
+        }
+        
+        (Union::new(arb_calls), Just(state))
+            .prop_flat_map(move |(call, mut state)| {
+                state.apply(call);
+                step(state, depositor, n - 1)
+            }).boxed()
+    }
+
+    step(CyclesLedgerCallsState::default(), depositor, len)
+
+}
+
+#[test]
+fn test() {
+    proptest!(|(state in arb_cycles_ledger_call_state(Principal::anonymous(), 10))| {
+        prop_assert_eq!(10, state.calls.len())
+    })
+}

--- a/cycles-ledger/tests/gen.rs
+++ b/cycles-ledger/tests/gen.rs
@@ -725,7 +725,9 @@ pub fn arb_cycles_ledger_call_state_from(
             let accounts: HashMap<_, _> = accounts.iter().copied().collect();
             let mut from_spender_amount = vec![];
             for ((from, spender), allowance) in allowances.as_ref() {
-                let Some(balance) = accounts.get(from) else { continue; };
+                let Some(balance) = accounts.get(from) else {
+                    continue;
+                };
                 from_spender_amount.push((*from, *spender, *allowance.min(balance)));
             }
             if !from_spender_amount.is_empty() {

--- a/cycles-ledger/tests/gen.rs
+++ b/cycles-ledger/tests/gen.rs
@@ -639,7 +639,7 @@ prop_compose! {
                         ((from, spender, from_balance) in arb_from_spender)
                         (from in Just(from),
                          spender in Just(spender),
-                         to in arb_account().prop_filter("cannot self tranasfer", move |to| &from != to),
+                         to in arb_account().prop_filter("cannot transfer to self", move |to| &from != to),
                          fee in option::of(Just(FEE.into())),
                          amount in (0..=(from_balance-FEE)).prop_map(Nat::from),
                          memo in option::of(arb_memo()),

--- a/cycles-ledger/tests/gen.rs
+++ b/cycles-ledger/tests/gen.rs
@@ -757,7 +757,7 @@ pub fn arb_cycles_ledger_call_state_from(
             // approve
             let select_account = select_account_and_balance.clone().prop_map(|(a, _)| a);
             let arb_expires_at = option::of(Just(
-                now_in_nanos_since_epoch.saturating_add(3600_000_000_000),
+                now_in_nanos_since_epoch.saturating_add(3_600_000_000_000),
             ));
             let arb_approve = arb_approve(
                 token_pool,

--- a/cycles-ledger/tests/gen.rs
+++ b/cycles-ledger/tests/gen.rs
@@ -67,7 +67,7 @@ impl From<TransferFromArgs> for CyclesLedgerCallArg {
     }
 }
 
-// An update call to the Cycle Ledger.
+// An update call to the cycles ledger.
 #[derive(Clone, Debug)]
 pub struct CyclesLedgerCall {
     caller: Principal,

--- a/cycles-ledger/tests/gen.rs
+++ b/cycles-ledger/tests/gen.rs
@@ -738,7 +738,7 @@ pub fn arb_cycles_ledger_call_state_from(
             panic!("BUG: no valid call can be performed on the current state");
         }
 
-        // Union panics if arb_calls is empty but it shouldn't be
+        // Union panics if arb_calls is empty but this shouldn't happen
         // as either the depositor has cycles or an account has funds.
         (Union::new(arb_calls), Just(state))
             .prop_flat_map(move |(call, mut state)| {

--- a/cycles-ledger/tests/gen.rs
+++ b/cycles-ledger/tests/gen.rs
@@ -223,7 +223,7 @@ impl<'a> IsCyclesLedger for CyclesLedgerInStateMachine<'a> {
                 )?
                 .map_err(|e| {
                     format!(
-                        "call to send(from:{}, to:{}, amount:{}) failed: {:?}",
+                        "call to withdraw(from:{}, to:{}, amount:{}) failed: {:?}",
                         Account {
                             owner: call.caller,
                             subaccount: arg.from_subaccount

--- a/cycles-ledger/tests/gen.rs
+++ b/cycles-ledger/tests/gen.rs
@@ -27,7 +27,7 @@ use proptest::{
 use serde::Deserialize;
 use serde_bytes::ByteBuf;
 
-// The arguments passed to an update call to the Cycles Ledger.
+// The arguments passed to an update call to the cycles ledger.
 #[derive(Clone, Debug)]
 pub enum CyclesLedgerCallArg {
     Approve(ApproveArgs),

--- a/cycles-ledger/tests/gen.rs
+++ b/cycles-ledger/tests/gen.rs
@@ -293,7 +293,7 @@ impl<'a> CyclesLedgerApplyCall for CyclesLedgerInStateMachine<'a> {
     }
 }
 
-// A in memory cycles-ledger state.
+// An in-memory cycles ledger state.
 #[derive(Clone, Debug, Default)]
 pub struct CyclesLedgerInMemory {
     pub balances: HashMap<Account, u128>,

--- a/cycles-ledger/tests/gen.rs
+++ b/cycles-ledger/tests/gen.rs
@@ -480,7 +480,7 @@ impl CyclesLedgerCallsState {
         }
     }
 
-    // Return the number of tokens available for minting
+    // Return the number of tokens available for minting.
     fn token_pool(&self) -> u128 {
         self.state.token_pool()
     }

--- a/cycles-ledger/tests/gen.rs
+++ b/cycles-ledger/tests/gen.rs
@@ -510,7 +510,7 @@ impl CyclesLedgerApplyCall for CyclesLedgerCallsState {
 
 fn arb_allowed_principal() -> impl Strategy<Value = Principal> {
     collection::vec(any::<u8>(), 0..30).prop_filter_map(
-        "Management and anonimous principals are disabled",
+        "Management and anonymous principals are disabled",
         |bytes| {
             let principal = Principal::from_slice(&bytes);
             if principal == Principal::management_canister() || principal == Principal::anonymous()

--- a/cycles-ledger/tests/gen.rs
+++ b/cycles-ledger/tests/gen.rs
@@ -582,8 +582,6 @@ prop_compose! {
                    memo in option::of(arb_memo()),
                   )
                   -> CyclesLedgerCall {
-        println!("    depositor_cyles: {}", depositor_cycles);
-        println!("    amount:          {}", amount.0.to_u128().unwrap());
         CyclesLedgerCall {
             caller: depositor,
             arg: (amount, DepositArg { to, memo, }).into()
@@ -703,7 +701,6 @@ pub fn arb_cycles_ledger_call_state_from(
         let token_pool = state.token_pool();
 
         let mut arb_calls = vec![];
-        println!("  depositor_cycles: {}", depositor_cycles);
         if depositor_cycles > 0 {
             let arb_deposit = arb_deposit(depositor, depositor_cycles);
             arb_calls.push(arb_deposit.boxed());
@@ -745,7 +742,6 @@ pub fn arb_cycles_ledger_call_state_from(
         // as either the depositor has cycles or an account has funds.
         (Union::new(arb_calls), Just(state))
             .prop_flat_map(move |(call, mut state)| {
-                println!("  next: {}", call);
                 state.apply(&call).unwrap();
                 step(state, depositor, n - 1)
             })

--- a/cycles-ledger/tests/gen.rs
+++ b/cycles-ledger/tests/gen.rs
@@ -353,7 +353,7 @@ impl CyclesLedgerApplyCall for CyclesLedgerInMemory {
             } => {
                 let amount = amount.0.to_u128().ok_or("amount is not a u128")?;
                 // The precise cost of calling the deposit endpoint is unknown.
-                // The depositor_cycles is decreased of an arbitary number plus
+                // depositor_cycles is decreased by an arbitrary number plus
                 // the amount.
                 self.depositor_cycles = self
                     .depositor_cycles

--- a/cycles-ledger/tests/gen.rs
+++ b/cycles-ledger/tests/gen.rs
@@ -463,8 +463,8 @@ impl CyclesLedgerApplyCall for CyclesLedgerInMemory {
     }
 }
 
-// Represent a set of valid calls and the
-// in-memory state that results from performing those
+// Represents a set of valid calls and the
+// in-memory state that results when performing those
 // calls.
 #[derive(Clone, Debug, Default)]
 pub struct CyclesLedgerCallsState {

--- a/cycles-ledger/tests/gen.rs
+++ b/cycles-ledger/tests/gen.rs
@@ -713,7 +713,7 @@ pub fn arb_cycles_ledger_call_state_from(
             let arb_approve = arb_approve(token_pool, allowances.clone(), select_account);
             arb_calls.push(arb_approve.boxed());
 
-            // send
+            // withdraw
             let arb_withdraw = arb_withdraw(select_account_and_balance.clone(), depositor);
             arb_calls.push(arb_withdraw.boxed());
 

--- a/cycles-ledger/tests/gen.rs
+++ b/cycles-ledger/tests/gen.rs
@@ -601,7 +601,7 @@ prop_compose! {
             arg: SendArgs {
                 from_subaccount: from.subaccount,
                 // Destination must exist so we pass the only
-                // canister that we know exists except for the Ledger.
+                // canister that we know exists except for the cycles ledger.
                 to: depositor,
                 created_at_time: None, // TODO
                 amount

--- a/cycles-ledger/tests/tests.rs
+++ b/cycles-ledger/tests/tests.rs
@@ -54,7 +54,8 @@ use serde_bytes::ByteBuf;
 use crate::{
     client::{
         approve, balance_of, canister_status, create_canister, fail_next_create_canister_with, fee,
-        get_allowance, get_block, get_tip_certificate, total_supply, transaction_timestamps, withdraw,
+        get_allowance, get_block, get_tip_certificate, total_supply, transaction_timestamps,
+        withdraw,
     },
     gen::{CyclesLedgerInStateMachine, IsCyclesLedger},
 };

--- a/cycles-ledger/tests/tests.rs
+++ b/cycles-ledger/tests/tests.rs
@@ -48,7 +48,7 @@ use crate::{
         approve, balance_of, fee, get_allowance, get_tip_certificate, send, total_supply,
         transaction_timestamps,
     },
-    gen::{CyclesLedgerApplyCall, CyclesLedgerInStateMachine},
+    gen::{CyclesLedgerInStateMachine, IsCyclesLedger},
 };
 
 mod client;
@@ -1614,10 +1614,10 @@ fn test_upgrade_preserves_state() {
         println!(" #{} {}", i, call);
 
         expected_state
-            .apply(&call)
+            .execute(&call)
             .expect("Unable to perform call on in-memory state");
         state_machine_caller
-            .apply(&call)
+            .execute(&call)
             .expect("Unable to perform call on StateMachine");
 
         // check that the state is consistent with `expected_state`

--- a/cycles-ledger/tests/tests.rs
+++ b/cycles-ledger/tests/tests.rs
@@ -1939,7 +1939,9 @@ fn test_upgrade_preserves_state() {
     let mut expected_state = CyclesLedgerInMemory::new(depositor_cycles);
 
     // generate a list of calls for the cycles ledger
-    let calls = gen::arb_cycles_ledger_call_state(depositor_id, depositor_cycles, 10)
+    let now =
+        (u64::MAX as u128).min(env.time().duration_since(UNIX_EPOCH).unwrap().as_nanos()) as u64;
+    let calls = gen::arb_cycles_ledger_call_state(depositor_id, depositor_cycles, 10, now)
         .new_tree(&mut TestRunner::default())
         .unwrap()
         .current()

--- a/cycles-ledger/tests/tests.rs
+++ b/cycles-ledger/tests/tests.rs
@@ -1600,7 +1600,7 @@ fn test_upgrade_preserves_state() {
 
     let mut expected_state = CyclesLedgerInMemory::new(depositor_cycles);
 
-    // generate a list of call for the cycles-ledger
+    // generate a list of calls for the cycles ledger
     let calls = gen::arb_cycles_ledger_call_state(depositor_id, depositor_cycles, 10)
         .new_tree(&mut TestRunner::default())
         .unwrap()

--- a/cycles-ledger/tests/tests.rs
+++ b/cycles-ledger/tests/tests.rs
@@ -22,6 +22,7 @@ use cycles_ledger::{
 use depositor::endpoints::InitArg as DepositorInitArg;
 use escargot::CargoBuild;
 use futures::FutureExt;
+use gen::CyclesLedgerInMemory;
 use ic_cbor::CertificateToCbor;
 use ic_cdk::api::call::RejectionCode;
 use ic_certificate_verification::VerifyCertificate;
@@ -42,12 +43,15 @@ use num_bigint::BigUint;
 use num_traits::ToPrimitive;
 use serde_bytes::ByteBuf;
 
-use crate::client::{
-    approve, balance_of, fee, get_allowance, get_tip_certificate, send, total_supply,
-    transaction_timestamps,
+use crate::{
+    client::{
+        approve, balance_of, fee, get_allowance, get_tip_certificate, send, total_supply,
+        transaction_timestamps,
+    }, gen::{CyclesLedgerApplyCall, CyclesLedgerInStateMachine},
 };
 
 mod client;
+mod gen;
 
 fn new_state_machine() -> StateMachine {
     let mut state_machine_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
@@ -1575,5 +1579,87 @@ fn test_icrc1_test_suite() {
         .unwrap()
     {
         panic!("The ICRC-1 test suite failed");
+    }
+}
+
+#[test]
+fn test_upgrade_preserves_state() {
+    use proptest::strategy::{Strategy, ValueTree};
+    use proptest::test_runner::TestRunner;
+
+    let env = &new_state_machine();
+    let ledger_id = install_ledger(env);
+    let depositor_id = install_depositor(env, ledger_id);
+    let depositor_cycles = env.cycle_balance(depositor_id);
+    let mut state_machine_caller = CyclesLedgerInStateMachine {
+        env,
+        ledger_id,
+        depositor_id,
+    };
+
+    let mut expected_state = CyclesLedgerInMemory::new(depositor_cycles);
+
+    // generate a list of call for the cycles-ledger
+    let calls = gen::arb_cycles_ledger_call_state(depositor_id, depositor_cycles, 10)
+        .new_tree(&mut TestRunner::default())
+        .unwrap()
+        .current()
+        .calls;
+
+    println!("=== Test started ===");
+
+    println!("Running the following operations on the Ledger:");
+    for (i, call) in calls.into_iter().enumerate() {
+        println!(" #{} {}", i, call);
+
+        expected_state.apply(&call).expect("Unable to perform call on in-memory state");
+        state_machine_caller.apply(&call).expect("Unable to perform call on StateMachine");
+
+        // check that the state is consistent with `expected_state`
+        check_ledger_state(&env, ledger_id, &expected_state);
+    }
+
+    let expected_blocks = get_raw_transactions(&env, ledger_id, vec![(0, u64::MAX)]);
+
+    // upgrade the ledger
+    let arg = Encode!(&None::<LedgerArgs>).unwrap();
+    env.upgrade_canister(ledger_id, get_wasm("cycles-ledger"), arg, None)
+        .unwrap();
+
+    // check that the state is still consistent with `expected_state`
+    // after the upgrade
+    check_ledger_state(&env, ledger_id, &expected_state);
+
+    // check that the blocks are all there after the upgrade
+    let after_upgrade_blocks = get_raw_transactions(&env, ledger_id, vec![(0, u64::MAX)]);
+    assert_eq!(expected_blocks, after_upgrade_blocks);
+}
+
+#[track_caller]
+fn check_ledger_state(
+    env: &StateMachine,
+    ledger_id: Principal,
+    expected_state: &CyclesLedgerInMemory,
+) {
+    assert_eq!(expected_state.total_supply, total_supply(env, ledger_id));
+
+    for (account, balance) in &expected_state.balances {
+        assert_eq!(
+            balance,
+            &balance_of(env, ledger_id, *account),
+            "balance_of({})",
+            account
+        );
+    }
+
+    for ((from, spender), allowance) in &expected_state.allowances {
+        let actual_allowance = get_allowance(env, ledger_id, *from, *spender).allowance;
+        assert_eq!(
+            allowance,
+            &actual_allowance.0.to_u128().unwrap(),
+            "allowance({}, {})",
+            from,
+            spender
+        );
     }
 }

--- a/cycles-ledger/tests/tests.rs
+++ b/cycles-ledger/tests/tests.rs
@@ -47,7 +47,8 @@ use crate::{
     client::{
         approve, balance_of, fee, get_allowance, get_tip_certificate, send, total_supply,
         transaction_timestamps,
-    }, gen::{CyclesLedgerApplyCall, CyclesLedgerInStateMachine},
+    },
+    gen::{CyclesLedgerApplyCall, CyclesLedgerInStateMachine},
 };
 
 mod client;
@@ -1612,14 +1613,18 @@ fn test_upgrade_preserves_state() {
     for (i, call) in calls.into_iter().enumerate() {
         println!(" #{} {}", i, call);
 
-        expected_state.apply(&call).expect("Unable to perform call on in-memory state");
-        state_machine_caller.apply(&call).expect("Unable to perform call on StateMachine");
+        expected_state
+            .apply(&call)
+            .expect("Unable to perform call on in-memory state");
+        state_machine_caller
+            .apply(&call)
+            .expect("Unable to perform call on StateMachine");
 
         // check that the state is consistent with `expected_state`
-        check_ledger_state(&env, ledger_id, &expected_state);
+        check_ledger_state(env, ledger_id, &expected_state);
     }
 
-    let expected_blocks = get_raw_transactions(&env, ledger_id, vec![(0, u64::MAX)]);
+    let expected_blocks = get_raw_transactions(env, ledger_id, vec![(0, u64::MAX)]);
 
     // upgrade the ledger
     let arg = Encode!(&None::<LedgerArgs>).unwrap();
@@ -1628,10 +1633,10 @@ fn test_upgrade_preserves_state() {
 
     // check that the state is still consistent with `expected_state`
     // after the upgrade
-    check_ledger_state(&env, ledger_id, &expected_state);
+    check_ledger_state(env, ledger_id, &expected_state);
 
     // check that the blocks are all there after the upgrade
-    let after_upgrade_blocks = get_raw_transactions(&env, ledger_id, vec![(0, u64::MAX)]);
+    let after_upgrade_blocks = get_raw_transactions(env, ledger_id, vec![(0, u64::MAX)]);
     assert_eq!(expected_blocks, after_upgrade_blocks);
 }
 


### PR DESCRIPTION
This PR adds a state machine library for the cycles-ledger as well as a test to check that upgrading the ledger preserves the state. The test uses the state machine library. Specifically, this PR adds:

1. A `gen.rs` file that contains `arb_cycles_ledger_call_state` which is a `proptest` generator of valid cycles-ledger calls.
2. `CyclesLedgerCall` which models a call to the cycles-ledger. A call is represented as the caller plus the arguments.
3. The `CyclesLedgerApplyCall` trait which abstract over "cycles ledgers" and allow to apply a `CyclesLedgerCall` to them.
4. Two implementation of `CyclesLedgerApplyCall`: 1) `CyclesLedgerInStateMachine` which models the cycles-ledger deployed in a `StateMachineTest` environment and 2) `CyclesLedgerInMemory` which models the cycles-ledger purely in memory.
5. The test `test_upgrade_preserves_state` which installs the cycles-ledger in a `StateMachineTest` environment, changes the state of such cycles-ledger with calls created by `arb_cycles_ledger_call_state`, upgrades the cycles-ledger and then validates that the state of the cycles-ledger after the upgrade is the same as before the upgrade.