### PR TITLE
fix: set correct controller if no controller is specified in canister settings

### DIFF
--- a/cycles-ledger/src/storage.rs
+++ b/cycles-ledger/src/storage.rs
@@ -1579,13 +1579,25 @@ pub async fn create_canister(
         let _ = reimburse();
     });
 
-    let argument = argument.unwrap_or_else(|| CmcCreateCanisterArgs {
-        settings: Some(CanisterSettings {
-            controllers: Some(vec![ic_cdk::api::caller()]),
-            ..Default::default()
-        }),
-        subnet_selection: None,
-    });
+    let argument = argument
+        .map(|arg| CmcCreateCanisterArgs {
+            settings: arg.settings.map(|settings| CanisterSettings {
+                controllers: Some(
+                    settings
+                        .controllers
+                        .unwrap_or_else(|| vec![ic_cdk::api::caller()]),
+                ),
+                ..settings
+            }),
+            ..arg
+        })
+        .unwrap_or_else(|| CmcCreateCanisterArgs {
+            settings: Some(CanisterSettings {
+                controllers: Some(vec![ic_cdk::api::caller()]),
+                ..Default::default()
+            }),
+            subnet_selection: None,
+        });
     let create_canister_result: Result<
         (Result<Principal, CmcCreateCanisterError>,),
         (RejectionCode, String),

--- a/cycles-ledger/tests/tests.rs
+++ b/cycles-ledger/tests/tests.rs
@@ -1791,7 +1791,7 @@ fn test_create_canister() {
         }
     );
 
-    // If CanisterSettings specify no controller the caller should still control the resulting canister
+    // If `CanisterSettings` do not specify a controller, the caller should still control the resulting canister
     let canister_settings = CanisterSettings {
         controllers: None,
         compute_allocation: Some(Nat::from(7)),

--- a/fake-cmc/src/main.rs
+++ b/fake-cmc/src/main.rs
@@ -49,7 +49,7 @@ async fn create_canister(arg: CmcCreateCanisterArgs) -> Result<Principal, CmcCre
     ic_cdk::api::call::msg_cycles_accept128(cycles);
 
     // "Canister <id> is already installed" happens because the canister id counter doesn't take into account that a canister with that id
-    // was already created using `provisional_create_canister_with_id`. Simply retry to try the next canister id.
+    // was already created using `provisional_create_canister_with_id`. Simply loop to try the next canister id.
     loop {
         match ic_cdk::api::management_canister::main::create_canister(
             CreateCanisterArgument {

--- a/fake-cmc/src/main.rs
+++ b/fake-cmc/src/main.rs
@@ -1,4 +1,5 @@
 use candid::{candid_method, Principal};
+use core::panic;
 use cycles_ledger::endpoints::{CmcCreateCanisterArgs, CmcCreateCanisterError};
 use fake_cmc::State;
 use ic_cdk::{
@@ -45,18 +46,26 @@ async fn create_canister(arg: CmcCreateCanisterArgs) -> Result<Principal, CmcCre
         };
         return Err(error);
     };
-
     ic_cdk::api::call::msg_cycles_accept128(cycles);
-    match ic_cdk::api::management_canister::main::create_canister(
-        CreateCanisterArgument {
-            settings: arg.settings,
-        },
-        cycles,
-    )
-    .await
-    {
-        Ok((record,)) => Ok(record.canister_id),
-        Err(error) => panic!("create_canister failed: {:?}", error),
+
+    // "Canister <id> is already installed" happens because the canister id counter doesn't take into account that a canister with that id
+    // was already created using `provisional_create_canister_with_id`. Simply retry to try the next canister id.
+    loop {
+        match ic_cdk::api::management_canister::main::create_canister(
+            CreateCanisterArgument {
+                settings: arg.settings.clone(),
+            },
+            cycles,
+        )
+        .await
+        {
+            Ok((record,)) => return Ok(record.canister_id),
+            Err(error) => {
+                if !error.1.contains("is already installed") {
+                    panic!("create_canister failed: {:?}", error)
+                }
+            }
+        }
     }
 }
 


### PR DESCRIPTION
Bug: If canister settings are `Some` but the controllers therein are `None` then the cycles ledger ends up as the sole controller of the new canister instead of the user/caller.