### PR TITLE
Update to newer IC version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ic-commit: [ a17247bd86c7aa4e87742bf74d108614580f216d ]
+        ic-commit: [ fed4316368b93245120ceb0596423c715bb31ff0 ]
 
     steps:
       - uses: actions/checkout@v2

--- a/fake-cmc/src/main.rs
+++ b/fake-cmc/src/main.rs
@@ -61,7 +61,7 @@ async fn create_canister(arg: CmcCreateCanisterArgs) -> Result<Principal, CmcCre
         {
             Ok((record,)) => return Ok(record.canister_id),
             Err(error) => {
-                if !error.1.contains("is already installed") {
+                if !error.1.contains("canister id already exists") {
                     panic!("create_canister failed: {:?}", error)
                 }
             }


### PR DESCRIPTION
Updating IC version to newer release. There was a change of an error message in case of duplicate canister, which needs to be updated in order for tests to work