### PR TITLE
fix: release workflow targets nonexistent file

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,19 +84,19 @@ jobs:
         run: |
           dfx build --check
           ls .dfx/local/canisters/cycles-**
+          ls .dfx/local/canisters/fake-cmc
           (cd .dfx/local/canisters/cycles-ledger && shasum -a 256 cycles-ledger.wasm.gz > cycles-ledger.wasm.gz.sha256)
           (cd .dfx/local/canisters/cycles-depositor && shasum -a 256 cycles-depositor.wasm.gz > cycles-depositor.wasm.gz.sha256)
           (cd .dfx/local/canisters/fake-cmc && shasum -a 256 fake-cmc.wasm.gz > fake-cmc.wasm.gz.sha256)
-          cp depositor/depositor.did .dfx/local/canisters/cycles-depositor/cycles-depositor.did
           gh release upload ${{ env.TAG }} .dfx/local/canisters/cycles-depositor/cycles-depositor.wasm.gz
           gh release upload ${{ env.TAG }} .dfx/local/canisters/cycles-depositor/cycles-depositor.wasm.gz.sha256
-          gh release upload ${{ env.TAG }} .dfx/local/canisters/cycles-depositor/cycles-depositor.did
+          gh release upload ${{ env.TAG }} cycles-depositor/cycles-depositor.did
           gh release upload ${{ env.TAG }} .dfx/local/canisters/cycles-ledger/cycles-ledger.wasm.gz
           gh release upload ${{ env.TAG }} .dfx/local/canisters/cycles-ledger/cycles-ledger.wasm.gz.sha256
           gh release upload ${{ env.TAG }} cycles-ledger/cycles-ledger.did
           gh release upload ${{ env.TAG }} .dfx/local/canisters/fake-cmc/fake-cmc.wasm.gz
           gh release upload ${{ env.TAG }} .dfx/local/canisters/fake-cmc/fake-cmc.wasm.gz.sha256
-          gh release upload ${{ env.TAG }} .dfx/local/canisters/fake-cmc/fake-cmc.did
+          gh release upload ${{ env.TAG }} fake-cmc/fake-cmc.did
           echo "uploaded!"
       - name: mark release as non-draft
         run: |


### PR DESCRIPTION
release fails with `.dfx/local/canisters/fake-cmc/fake-cmc.did: no such file or directory`