### PR TITLE
Fix: Remove scopeguards

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -369,7 +369,6 @@ dependencies = [
  "num-bigint",
  "num-traits",
  "proptest",
- "scopeguard",
  "serde",
  "serde_bytes",
  "serde_cbor",

--- a/cycles-ledger/Cargo.toml
+++ b/cycles-ledger/Cargo.toml
@@ -32,7 +32,6 @@ thiserror = "1.0"
 ic-canister-log = "0.2.0"
 ic-canisters-http-types = { git = "https://github.com/dfinity/ic", rev = "b2f18ac0794d2225b53d9c3190b60dbadb4ac9b9" }
 ic-metrics-encoder = "1.1"
-scopeguard = "1.2.0"
 serde_cbor = "0.11.2"
 serde_json = "1.0.107"
 


### PR DESCRIPTION
Removing scopeguards for panics. They are not needed, since the relevant functions won't panic in practice. The only situations where these functions can panic is if there is a failure in encoding call arguments. Such problem would be caught by tests.