### PR TITLE
Chore: Remove serde cbor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -371,7 +371,6 @@ dependencies = [
  "proptest",
  "serde",
  "serde_bytes",
- "serde_cbor",
  "serde_json",
  "thiserror",
 ]
@@ -1447,16 +1446,6 @@ version = "0.11.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab33ec92f677585af6d88c65593ae2375adde54efdbf16d597f2cbc7a6d368ff"
 dependencies = [
- "serde",
-]
-
-[[package]]
-name = "serde_cbor"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bef2ebfde456fb76bbcf9f59315333decc4fda0b2b44b420243c11e0f5ec1f5"
-dependencies = [
- "half",
  "serde",
 ]
 

--- a/cycles-ledger/Cargo.toml
+++ b/cycles-ledger/Cargo.toml
@@ -32,7 +32,6 @@ thiserror = "1.0"
 ic-canister-log = "0.2.0"
 ic-canisters-http-types = { git = "https://github.com/dfinity/ic", rev = "b2f18ac0794d2225b53d9c3190b60dbadb4ac9b9" }
 ic-metrics-encoder = "1.1"
-serde_cbor = "0.11.2"
 serde_json = "1.0.107"
 
 [dev-dependencies]

--- a/cycles-ledger/src/storage.rs
+++ b/cycles-ledger/src/storage.rs
@@ -421,17 +421,18 @@ impl State {
             Some(certificate) => ByteBuf::from(certificate),
             None => return None,
         };
-        let hash_tree = ByteBuf::from(
-            serde_cbor::to_vec(
-                &self
-                    .cache
-                    .hash_tree
-                    .value_range(b"last_block_hash", b"last_block_index"),
-            )
-            .expect(
-                "Bug: unable to write last_block_hash and last_block_index values in the hash_tree",
-            ),
+        let mut hash_tree_buf = vec![];
+        ciborium::ser::into_writer(
+            &self
+                .cache
+                .hash_tree
+                .value_range(b"last_block_hash", b"last_block_index"),
+            &mut hash_tree_buf,
+        )
+        .expect(
+            "Bug: unable to write last_block_hash and last_block_index values in the hash_tree",
         );
+        let hash_tree = ByteBuf::from(hash_tree_buf);
         Some(DataCertificate {
             certificate,
             hash_tree,

--- a/cycles-ledger/tests/tests.rs
+++ b/cycles-ledger/tests/tests.rs
@@ -1441,7 +1441,7 @@ fn validate_certificate(
         _ => panic!("Unable to find the certificate_data_hash for the ledger canister in the hash_tree (hash_tree: {:?}, path: {:?})", certificate.tree, certified_data_path),
     };
 
-    let hash_tree: HashTree = serde_cbor::de::from_slice(hash_tree.as_slice())
+    let hash_tree: HashTree = ciborium::de::from_reader(hash_tree.as_slice())
         .expect("Unable to deserialize CBOR encoded hash_tree");
 
     assert_eq!(certified_data_hash, hash_tree.digest());


### PR DESCRIPTION
Unifying the code to use ciborium everywhere, so that we can remove serde_cbor from dependencies