### PR TITLE
feat: pullable

### DIFF
--- a/dfx.json
+++ b/dfx.json
@@ -5,7 +5,13 @@
       "candid": "./cycles-ledger/cycles-ledger.did",
       "package": "cycles-ledger",
       "optimize": "cycles",
-      "gzip": true
+      "gzip": true,
+      "pullable": {
+        "dependencies": [],
+        "wasm_url": "https://github.com/dfinity/cycles-ledger/releases/latest/download/cycles-ledger.wasm.gz",
+        "wasm_hash_url": "https://github.com/dfinity/cycles-ledger/releases/latest/download/cycles-ledger.wasm.gz.sha256",
+        "init_guide": "(variant{Init=record{max_transactions_per_request=1000}})"
+      }
     },
     "depositor": {
       "type": "rust",


### PR DESCRIPTION
This PR simply adds the required pullable metadata.

To verify the overall workflow, we will need to make a new release so that the wasm module in GitHub release artifacts will have these metadata. And that release should not be "pre-release" in order to be accessible  using "latest" label.

And there is an issue on the `dfx` side which requires `wasm_hash_url` to contains the hash only. Instead of modifying the CI of this project, I change the `dfx deps pull` to accept `shasum` output. [PR](https://github.com/dfinity/sdk/pull/3563) is pending.

I removed the "pre-release" label of the 0.2.8 release. So that I could verify the `wasm_url` and `wasm_hash_url` can be reached.

And I also verified the content of `init_guide` field is correct to deploy the canister locally.