### PR TITLE
fix: pullable init_guide and add init_arg

### DIFF
--- a/dfx.json
+++ b/dfx.json
@@ -10,7 +10,8 @@
         "dependencies": [],
         "wasm_url": "https://github.com/dfinity/cycles-ledger/releases/latest/download/cycles-ledger.wasm.gz",
         "wasm_hash_url": "https://github.com/dfinity/cycles-ledger/releases/latest/download/cycles-ledger.wasm.gz.sha256",
-        "init_guide": "(variant{Init=record{max_transactions_per_request=1000}})"
+        "init_guide": "Set max_blocks_per_request in Init record",
+        "init_arg": "(variant{Init=record{max_blocks_per_request=1000}})"
       }
     },
     "depositor": {


### PR DESCRIPTION
`max_transactions_per_request` was renamed to `max_blocks_per_request`

`dfx` will (starting from v0.17.0) allow providers to set `init_arg` in pullable metadata.