### PR TITLE
chore: switch to `tokio::test` for the `test_icrc1_test_suite`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,21 @@
 version = 3
 
 [[package]]
+name = "addr2line"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a30b2e23b9e17a9f90641c7ab1549cd9b44f296d3ccbf309d2863cfe398a0cb"
+dependencies = [
+ "gimli",
+]
+
+[[package]]
+name = "adler"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
+
+[[package]]
 name = "ahash"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -78,6 +93,21 @@ name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
+
+[[package]]
+name = "backtrace"
+version = "0.3.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2089b7e3f35b9dd2d0ed921ead4f6d318c27680d4a5bd167b3ee120edb105837"
+dependencies = [
+ "addr2line",
+ "cc",
+ "cfg-if",
+ "libc",
+ "miniz_oxide",
+ "object",
+ "rustc-demangle",
+]
 
 [[package]]
 name = "base32"
@@ -349,7 +379,6 @@ dependencies = [
  "ciborium",
  "depositor",
  "escargot",
- "futures",
  "hex",
  "ic-canister-log",
  "ic-canisters-http-types",
@@ -373,6 +402,7 @@ dependencies = [
  "serde_bytes",
  "serde_json",
  "thiserror",
+ "tokio",
 ]
 
 [[package]]
@@ -649,6 +679,12 @@ dependencies = [
  "libc",
  "wasi",
 ]
+
+[[package]]
+name = "gimli"
+version = "0.28.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
 
 [[package]]
 name = "half"
@@ -1087,6 +1123,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
+name = "miniz_oxide"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d811f3e15f28568be3407c8e7fdb6514c1cda3cb30683f15b6a1a1dc4ea14a7"
+dependencies = [
+ "adler",
+]
+
+[[package]]
 name = "miracl_core_bls12381"
 version = "4.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1138,6 +1183,15 @@ checksum = "39e3200413f237f41ab11ad6d161bc7239c84dcb631773ccd7de3dfe4b5c267c"
 dependencies = [
  "autocfg",
  "libm",
+]
+
+[[package]]
+name = "object"
+version = "0.32.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6a622008b6e321afc04970976f62ee297fdbaa6f95318ca343e3eebb9648441"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -1389,6 +1443,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
 
 [[package]]
+name = "rustc-demangle"
+version = "0.1.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
+
+[[package]]
 name = "rustix"
 version = "0.38.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1628,6 +1688,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
 dependencies = [
  "crunchy",
+]
+
+[[package]]
+name = "tokio"
+version = "1.36.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61285f6515fa018fb2d1e46eb21223fff441ee8db5d0f1435e8ab4f5cdb80931"
+dependencies = [
+ "backtrace",
+ "pin-project-lite",
+ "tokio-macros",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b8a1e28f2deaa14e508979454cb3a223b10b938b45af148bc0986de36f1923b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.41",
 ]
 
 [[package]]

--- a/cycles-ledger/Cargo.toml
+++ b/cycles-ledger/Cargo.toml
@@ -40,8 +40,8 @@ ic-certificate-verification = "2.3.0"
 ic-test-state-machine-client = "3.0.0"
 icrc1-test-env-state-machine = "0.1.2"
 icrc1-test-suite = "0.1.2"
-futures = "0.3.28"
 proptest = "1.2.0"
+tokio = { version = "1.36.0", features = ["rt", "macros"] }
 
 [features]
 testing = []

--- a/cycles-ledger/tests/tests.rs
+++ b/cycles-ledger/tests/tests.rs
@@ -26,7 +26,6 @@ use cycles_ledger::{
 };
 use depositor::endpoints::InitArg as DepositorInitArg;
 use escargot::CargoBuild;
-use futures::FutureExt;
 use gen::CyclesLedgerInMemory;
 use ic_cbor::CertificateToCbor;
 use ic_cdk::api::{call::RejectionCode, management_canister::provisional::CanisterSettings};
@@ -1891,8 +1890,8 @@ fn test_change_index_id() {
     assert!(metadata.iter().all(|(k, _)| k != "dfn:index_id"));
 }
 
-#[test]
-fn test_icrc1_test_suite() {
+#[tokio::test]
+async fn test_icrc1_test_suite() {
     let env = new_state_machine();
     let ledger_id = install_ledger(&env);
     let depositor_id = install_depositor(&env, ledger_id);
@@ -1910,13 +1909,8 @@ fn test_icrc1_test_suite() {
     #[allow(clippy::arc_with_non_send_sync)]
     let ledger_env =
         icrc1_test_env_state_machine::SMLedger::new(Arc::new(env), ledger_id, user.owner);
-    let tests = icrc1_test_suite::test_suite(ledger_env)
-        .now_or_never()
-        .unwrap();
-    if !icrc1_test_suite::execute_tests(tests)
-        .now_or_never()
-        .unwrap()
-    {
+    let tests = icrc1_test_suite::test_suite(ledger_env).await;
+    if !icrc1_test_suite::execute_tests(tests).await {
         panic!("The ICRC-1 test suite failed");
     }
 }


### PR DESCRIPTION
The current `test_icrc1_test_suite` implementation uses `FutureExt`'s [`now_or_never`](https://docs.rs/futures-util/latest/futures_util/future/trait.FutureExt.html#method.now_or_never) to deal with async code. The issue with that is that in case of timeout you get an `unwrap` error instead of a timeout. This PR changes that by making the test async and using `tokio::test` macro.