### PR TITLE
chore: tests cleanup and ergonomics

### DIFF
--- a/cycles-ledger/tests/client.rs
+++ b/cycles-ledger/tests/client.rs
@@ -131,10 +131,10 @@ pub fn get_block(env: &StateMachine, ledger_id: Principal, block_index: Nat) -> 
 pub fn withdraw(
     env: &StateMachine,
     ledger_id: Principal,
-    from: Account,
+    caller: Principal,
     args: WithdrawArgs,
 ) -> Result<Nat, endpoints::WithdrawError> {
-    update_or_panic(env, ledger_id, from.owner, "withdraw", args)
+    update_or_panic(env, ledger_id, caller, "withdraw", args)
 }
 
 pub fn create_canister(

--- a/cycles-ledger/tests/client.rs
+++ b/cycles-ledger/tests/client.rs
@@ -53,7 +53,7 @@ where
     }
 }
 
-// panics in case the canister is unreachable or it has rejected the update
+// Panics if the canister is unreachable or it has rejected the update.
 pub fn update_or_panic<I, O>(
     env: &StateMachine,
     canister_id: Principal,

--- a/cycles-ledger/tests/client.rs
+++ b/cycles-ledger/tests/client.rs
@@ -29,7 +29,7 @@ use icrc_ledger_types::{
 use num_traits::ToPrimitive;
 use serde::Deserialize;
 
-// panics in case the canister is unreachable or it has rejected the query
+// Panics if the canister is unreachable or it has rejected the query.
 pub fn query_or_panic<I, O>(
     env: &StateMachine,
     canister_id: Principal,

--- a/cycles-ledger/tests/tests.rs
+++ b/cycles-ledger/tests/tests.rs
@@ -609,8 +609,8 @@ fn test_withdraw_flow() {
 }
 
 // A test to check that `DuplicateError` is returned on a duplicate `withdraw` request
-// and not `InsufficientFundsError`, in case when there is not enough funds
-// to execute it a second time
+// and not `InsufficientFundsError`, in case of insufficient funds
+// to execute it a second time.
 #[test]
 fn test_withdraw_duplicate() {
     let env = TestEnv::setup();

--- a/cycles-ledger/tests/tests.rs
+++ b/cycles-ledger/tests/tests.rs
@@ -306,7 +306,7 @@ impl TestEnv {
     }
 
     // Validate that the given [response_certificate], [last_block_index], and [last_block_hash]
-    // match the certified data from the ledger
+    // match the certified data from the ledger.
     #[track_caller]
     fn validate_certificate(&self, last_block_index: u64, last_block_hash: Hash) {
         let DataCertificate {

--- a/cycles-ledger/tests/tests.rs
+++ b/cycles-ledger/tests/tests.rs
@@ -951,7 +951,7 @@ fn test_approve_duplicate() {
     assert_eq!(allowance.expires_at, None);
     assert_eq!(env.icrc1_balance_of(from), Nat::from(1_000_000_000 - FEE));
 
-    // second approve should fail with deduplicate
+    // second approve should fail with [ApproveError::Duplicate]
     assert_eq!(
         env.icrc2_approve(from.owner, args),
         Err(ApproveError::Duplicate { duplicate_of })

--- a/cycles-ledger/tests/tests.rs
+++ b/cycles-ledger/tests/tests.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::HashSet,
+    collections::{BTreeMap, HashSet},
     path::PathBuf,
     sync::Arc,
     time::{Duration, SystemTime, UNIX_EPOCH},
@@ -7,12 +7,12 @@ use std::{
 
 use assert_matches::assert_matches;
 use candid::{CandidType, Decode, Encode, Nat, Principal};
-use client::{deposit, get_metadata, get_raw_blocks, transaction_hashes, transfer, transfer_from};
+use client::{deposit, icrc3_get_blocks};
 use cycles_ledger::{
     config::{self, Config as LedgerConfig, FEE, MAX_MEMO_LENGTH},
     endpoints::{
-        ChangeIndexId, DataCertificate, GetBlocksResult, LedgerArgs, UpgradeArgs, WithdrawArgs,
-        WithdrawError,
+        BlockWithId, ChangeIndexId, DataCertificate, DepositResult, GetBlocksResult, LedgerArgs,
+        UpgradeArgs, WithdrawArgs, WithdrawError,
     },
     memo::encode_withdraw_memo,
     storage::{
@@ -37,14 +37,15 @@ use ic_certification::{
     hash_tree::{HashTreeNode, SubtreeLookupResult},
     Certificate, HashTree, LookupResult,
 };
-use ic_test_state_machine_client::{ErrorCode, StateMachine, WasmResult};
+use ic_test_state_machine_client::{CallError, ErrorCode, StateMachine, WasmResult};
 use icrc_ledger_types::{
+    icrc::generic_metadata_value::MetadataValue,
     icrc1::{
         account::Account,
-        transfer::TransferArg as TransferArgs,
-        transfer::{Memo, TransferError},
+        transfer::{Memo, TransferArg as TransferArgs, TransferError},
     },
     icrc2::{
+        allowance::Allowance,
         approve::{ApproveArgs, ApproveError},
         transfer_from::{TransferFromArgs, TransferFromError},
     },
@@ -55,9 +56,8 @@ use serde_bytes::ByteBuf;
 
 use crate::{
     client::{
-        approve, balance_of, canister_status, create_canister, fail_next_create_canister_with, fee,
-        get_allowance, get_block, get_tip_certificate, total_supply, transaction_timestamps,
-        withdraw,
+        canister_status, create_canister, fail_next_create_canister_with, get_block,
+        icrc1_balance_of, icrc1_total_supply, icrc2_allowance,
     },
     gen::{CyclesLedgerInStateMachine, IsCyclesLedger},
 };
@@ -156,46 +156,235 @@ fn install_fake_cmc(env: &StateMachine) {
 pub fn account(owner: u64, subaccount: Option<u64>) -> Account {
     Account {
         owner: Principal::from_slice(owner.to_be_bytes().as_slice()),
-        subaccount: subaccount
-            .map(|subaccount| subaccount.to_be_bytes().as_slice().try_into().unwrap()),
+        subaccount: subaccount.map(|subaccount| {
+            let mut subaccount_bytes = [0u8; 32];
+            subaccount_bytes[24..32].copy_from_slice(subaccount.to_be_bytes().as_slice());
+            subaccount_bytes
+        }),
+    }
+}
+
+struct TestEnv {
+    pub state_machine: StateMachine,
+    pub ledger_id: Principal,
+    pub depositor_id: Principal,
+}
+
+impl TestEnv {
+    fn setup() -> Self {
+        let state_machine = new_state_machine();
+        let ledger_id = install_ledger(&state_machine);
+        let depositor_id = install_depositor(&state_machine, ledger_id);
+        Self {
+            state_machine,
+            ledger_id,
+            depositor_id,
+        }
+    }
+
+    fn setup_with_ledger_conf(conf: LedgerConfig) -> Self {
+        let state_machine = new_state_machine();
+        let ledger_id = install_ledger_with_conf(&state_machine, conf);
+        let depositor_id = install_depositor(&state_machine, ledger_id);
+        Self {
+            state_machine,
+            ledger_id,
+            depositor_id,
+        }
+    }
+
+    fn upgrade_ledger(&self, args: Option<UpgradeArgs>) -> Result<(), CallError> {
+        let arg = Encode!(&Some(LedgerArgs::Upgrade(args))).unwrap();
+        self.state_machine
+            .upgrade_canister(self.ledger_id, get_wasm("cycles-ledger"), arg, None)
+    }
+
+    fn deposit(&self, to: Account, amount: u128, memo: Option<Memo>) -> DepositResult {
+        client::deposit(&self.state_machine, self.depositor_id, to, amount, memo)
+    }
+
+    fn get_block(&self, block_index: Nat) -> Block {
+        client::get_block(&self.state_machine, self.ledger_id, block_index)
+    }
+
+    fn icrc1_balance_of(&self, account: Account) -> u128 {
+        client::icrc1_balance_of(&self.state_machine, self.ledger_id, account)
+    }
+
+    fn icrc1_fee(&self) -> u128 {
+        client::icrc1_fee(&self.state_machine, self.ledger_id)
+    }
+
+    fn icrc1_metadata(&self) -> Vec<(String, MetadataValue)> {
+        client::icrc1_metadata(&self.state_machine, self.ledger_id)
+    }
+
+    fn icrc1_total_supply(&self) -> u128 {
+        client::icrc1_total_supply(&self.state_machine, self.ledger_id)
+    }
+
+    fn icrc1_transfer(&self, caller: Principal, args: TransferArgs) -> Result<Nat, TransferError> {
+        client::icrc1_transfer(&self.state_machine, self.ledger_id, caller, args)
+    }
+
+    fn icrc1_transfer_or_trap(&self, caller: Principal, args: TransferArgs) -> Nat {
+        self.icrc1_transfer(caller, args.clone())
+            .unwrap_or_else(|err|
+                panic!("Call to icrc1_transfer({args:?}) from caller {caller} failed with error {err}"))
+    }
+
+    fn icrc2_allowance(&self, from: Account, spender: Account) -> Allowance {
+        client::icrc2_allowance(&self.state_machine, self.ledger_id, from, spender)
+    }
+
+    fn icrc2_approve(&self, caller: Principal, args: ApproveArgs) -> Result<Nat, ApproveError> {
+        client::icrc2_approve(&self.state_machine, self.ledger_id, caller, args)
+    }
+
+    fn icrc2_approve_or_trap(&self, caller: Principal, args: ApproveArgs) -> Nat {
+        self.icrc2_approve(caller, args.clone())
+            .unwrap_or_else(|err|
+                panic!("Call to icrc2_approve({args:?}) from caller {caller} failed with error {err:?}"))
+    }
+
+    fn icrc2_transfer_from(
+        &self,
+        caller: Principal,
+        args: TransferFromArgs,
+    ) -> Result<Nat, TransferFromError> {
+        client::icrc2_transfer_from(&self.state_machine, self.ledger_id, caller, args)
+    }
+
+    fn icrc2_transfer_from_or_trap(&self, caller: Principal, args: TransferFromArgs) -> Nat {
+        self.icrc2_transfer_from(caller, args.clone())
+            .unwrap_or_else(|err|
+                panic!("Call to icrc2_transfer_from({args:?}) from caller {caller} failed with error {err:?}"))
+    }
+
+    fn icrc3_get_blocks<N: Into<Nat>>(&self, start_lengths: Vec<(N, N)>) -> GetBlocksResult {
+        client::icrc3_get_blocks(&self.state_machine, self.ledger_id, start_lengths)
+    }
+
+    fn icrc3_get_tip_certificate(&self) -> DataCertificate {
+        client::get_tip_certificate(&self.state_machine, self.ledger_id)
+    }
+
+    fn nanos_since_epoch(&self) -> u128 {
+        self.state_machine
+            .time()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    }
+
+    fn nanos_since_epoch_u64(&self) -> u64 {
+        (u64::MAX as u128)
+            .min(self.nanos_since_epoch())
+            .try_into()
+            .unwrap()
+    }
+
+    fn withdraw(&self, from: Account, args: WithdrawArgs) -> Result<Nat, WithdrawError> {
+        client::withdraw(&self.state_machine, self.ledger_id, from, args)
+    }
+
+    fn withdraw_or_trap(&self, from: Account, args: WithdrawArgs) -> Nat {
+        self.withdraw(from, args.clone())
+            .unwrap_or_else(|err|
+                panic!("Call to withdraw({args:?}) from caller {from} failed with error {err:?}"))
+    }
+
+    fn transaction_hashes(&self) -> BTreeMap<[u8; 32], u64> {
+        client::transaction_hashes(&self.state_machine, self.ledger_id)
+    }
+
+    fn transaction_timestamps(&self) -> BTreeMap<(u64, u64), ()> {
+        client::transaction_timestamps(&self.state_machine, self.ledger_id)
+    }
+
+    // Validate that the given [response_certificate], [last_block_index], and [last_block_hash]
+    // match the certified data from the ledger
+    #[track_caller]
+    fn validate_certificate(&self, last_block_index: u64, last_block_hash: Hash) {
+        let DataCertificate {
+            certificate,
+            hash_tree,
+        } = self.icrc3_get_tip_certificate();
+        let certificate = Certificate::from_cbor(certificate.as_slice()).unwrap();
+        let root_key = self.state_machine.root_key();
+        assert_matches!(
+            certificate.verify(self.ledger_id.as_slice(), &root_key),
+            Ok(_)
+        );
+
+        let certified_data_path: [&[u8]; 3] = [
+            "canister".as_bytes(),
+            self.ledger_id.as_slice(),
+            "certified_data".as_bytes(),
+        ];
+
+        let certified_data_hash = match certificate.tree.lookup_path(&certified_data_path) {
+            LookupResult::Found(v) => v,
+            _ => panic!("Unable to find the certificate_data_hash for the ledger canister in the hash_tree (hash_tree: {:?}, path: {:?})", certificate.tree, certified_data_path),
+        };
+
+        let hash_tree: HashTree = ciborium::de::from_reader(hash_tree.as_slice())
+            .expect("Unable to deserialize CBOR encoded hash_tree");
+
+        assert_eq!(certified_data_hash, hash_tree.digest());
+
+        let expected_last_block_hash = match hash_tree.lookup_subtree([b"last_block_hash"]) {
+            SubtreeLookupResult::Found(tree) => match tree.as_ref() {
+                HashTreeNode::Leaf(last_block_hash) => last_block_hash.clone(),
+                _ => panic!("last_block_hash value in the hash_tree should be a leaf"),
+            },
+            _ => panic!("last_block_hash not found in the response hash_tree"),
+        };
+        assert_eq!(last_block_hash.to_vec(), expected_last_block_hash);
+
+        let expected_last_block_index = match hash_tree.lookup_subtree([b"last_block_index"]) {
+            SubtreeLookupResult::Found(tree) => match tree.as_ref() {
+                HashTreeNode::Leaf(last_block_index_bytes) => {
+                    u64::from_be_bytes(last_block_index_bytes.clone().try_into().unwrap())
+                }
+                _ => panic!("last_block_index value in the hash_tree should be a Leaf"),
+            },
+            _ => panic!("last_block_hash not found in the response hash_tree"),
+        };
+        assert_eq!(last_block_index, expected_last_block_index);
     }
 }
 
 #[test]
 fn test_deposit_flow() {
-    let env = &new_state_machine();
-    let ledger_id = install_ledger(env);
-    let depositor_id = install_depositor(env, ledger_id);
+    let env = TestEnv::setup();
     let user = account(0, None);
 
     // 0.0 Check that the total supply is 0.
-    assert_eq!(total_supply(env, ledger_id), 0u128);
+    assert_eq!(env.icrc1_total_supply(), 0u128);
 
     // 0.1 Check that the user doesn't have any tokens before the first deposit.
-    assert_eq!(balance_of(env, ledger_id, user), 0u128);
+    assert_eq!(env.icrc1_balance_of(user), 0u128);
 
     // 1 Make the first deposit to the user and check the result.
-    let deposit_res = deposit(env, depositor_id, user, 1_000_000_000, None);
+    let deposit_res = env.deposit(user, 1_000_000_000, None);
     assert_eq!(deposit_res.block_index, Nat::from(0_u128));
     assert_eq!(deposit_res.balance, Nat::from(1_000_000_000_u128));
 
     // 1.0 Check that the right amount of tokens have been minted.
-    assert_eq!(total_supply(env, ledger_id), 1_000_000_000);
+    assert_eq!(env.icrc1_total_supply(), 1_000_000_000);
 
     // 1.1 Check that the user has the right balance.
-    assert_eq!(balance_of(env, ledger_id, user), 1_000_000_000);
+    assert_eq!(env.icrc1_balance_of(user), 1_000_000_000);
 
     // 1.2 Check that the block created is correct:
-    let block0 = get_block(env, ledger_id, deposit_res.block_index);
+    let block0 = env.get_block(deposit_res.block_index);
     // 1.2.0 first block has no parent hash.
     assert_eq!(block0.phash, None);
     // 1.2.1 effective fee of mint blocks is 0.
     assert_eq!(block0.effective_fee, Some(0));
     // 1.2.2 timestamp is set by the ledger.
-    assert_eq!(
-        block0.timestamp as u128,
-        env.time().duration_since(UNIX_EPOCH).unwrap().as_nanos()
-    );
+    assert_eq!(block0.timestamp as u128, env.nanos_since_epoch());
     // 1.2.3 transaction.created_at_time is not set.
     assert_eq!(block0.transaction.created_at_time, None);
     // 1.2.4 transaction.memo is not set because the user didn't set it.
@@ -212,27 +401,24 @@ fn test_deposit_flow() {
 
     // 2 Make another deposit to the user and check the result.
     let memo = Memo::from(vec![0xa, 0xb, 0xc, 0xd, 0xe, 0xf]);
-    let deposit_res = deposit(env, depositor_id, user, 500_000_000, Some(memo.clone()));
+    let deposit_res = env.deposit(user, 500_000_000, Some(memo.clone()));
     assert_eq!(deposit_res.block_index, Nat::from(1_u128));
     assert_eq!(deposit_res.balance, Nat::from(1_500_000_000_u128));
 
     // 2.0 Check that the right amount of tokens have been minted
-    assert_eq!(total_supply(env, ledger_id), 1_500_000_000);
+    assert_eq!(env.icrc1_total_supply(), 1_500_000_000);
 
     // 2.1 Check that the user has the right balance after both deposits.
-    assert_eq!(balance_of(env, ledger_id, user), 1_500_000_000);
+    assert_eq!(env.icrc1_balance_of(user), 1_500_000_000);
 
     // 2.2 Check that the block created is correct:
-    let block1 = get_block(env, ledger_id, deposit_res.block_index);
+    let block1 = env.get_block(deposit_res.block_index);
     // 2.2.0 second block has the first block hash as parent hash.
     assert_eq!(block1.phash, Some(block0.hash().unwrap()));
     // 2.2.1 effective fee of mint blocks is 0.
     assert_eq!(block1.effective_fee, Some(0));
     // 2.2.2 timestamp is set by the ledger.
-    assert_eq!(
-        block1.timestamp as u128,
-        env.time().duration_since(UNIX_EPOCH).unwrap().as_nanos()
-    );
+    assert_eq!(block1.timestamp as u128, env.nanos_since_epoch());
     // 2.2.3 transaction.created_at_time is not set.
     assert_eq!(block1.transaction.created_at_time, None);
     // 2.2.4 transaction.memo not set because the user set it.
@@ -251,140 +437,111 @@ fn test_deposit_flow() {
 #[test]
 #[should_panic]
 fn test_deposit_amount_below_fee() {
-    let env = &new_state_machine();
-    let ledger_id = install_ledger(env);
-    let depositor_id = install_depositor(env, ledger_id);
-    let user = Account {
-        owner: Principal::from_slice(&[1]),
-        subaccount: None,
-    };
+    let env = TestEnv::setup();
+    let user = account(1, None);
 
     // Attempt to deposit fewer than [config::FEE] cycles. This call should panic.
-    let _deposit_result = deposit(env, depositor_id, user, config::FEE - 1, None);
+    let _deposit_result = env.deposit(user, config::FEE - 1, None);
 }
 
 #[test]
 fn test_withdraw_flow() {
     // TODO(SDK-1145): Add re-entrancy test
 
-    let env = &new_state_machine();
-    let ledger_id = install_ledger(env);
-    let depositor_id = install_depositor(env, ledger_id);
-    let user_main_account = Account {
-        owner: Principal::from_slice(&[1]),
-        subaccount: None,
-    };
-    let user_subaccount_1 = Account {
-        owner: Principal::from_slice(&[1]),
-        subaccount: Some([1; 32]),
-    };
-    let user_subaccount_2 = Account {
-        owner: Principal::from_slice(&[1]),
-        subaccount: Some([2; 32]),
-    };
-    let user_subaccount_3 = Account {
-        owner: Principal::from_slice(&[1]),
-        subaccount: Some([3; 32]),
-    };
-    let user_subaccount_4 = Account {
-        owner: Principal::from_slice(&[1]),
-        subaccount: Some([4; 32]),
-    };
-    let withdraw_receiver = env.create_canister(None);
+    let env = TestEnv::setup();
+    let user_main_account = account(1, None);
+    let user_subaccount_1 = account(1, Some(1));
+    let user_subaccount_2 = account(1, Some(2));
+    let user_subaccount_3 = account(1, Some(3));
+    let user_subaccount_4 = account(1, Some(4));
+    let withdraw_receiver = env.state_machine.create_canister(None);
 
     // make deposits to the user and check the result
-    let deposit_res = deposit(env, depositor_id, user_main_account, 1_000_000_000, None);
+    let deposit_res = env.deposit(user_main_account, 1_000_000_000, None);
     assert_eq!(deposit_res.block_index, 0_u128);
     assert_eq!(deposit_res.balance, 1_000_000_000_u128);
-    deposit(env, depositor_id, user_subaccount_1, 1_000_000_000, None);
-    deposit(env, depositor_id, user_subaccount_2, 1_000_000_000, None);
-    deposit(env, depositor_id, user_subaccount_3, 1_000_000_000, None);
-    deposit(env, depositor_id, user_subaccount_4, 1_000_000_000, None);
+    let _deposit_res = env.deposit(user_subaccount_1, 1_000_000_000, None);
+    let _deposit_res = env.deposit(user_subaccount_2, 1_000_000_000, None);
+    let _deposit_res = env.deposit(user_subaccount_3, 1_000_000_000, None);
+    let _deposit_res = env.deposit(user_subaccount_4, 1_000_000_000, None);
     let mut expected_total_supply = 5_000_000_000;
-    assert_eq!(total_supply(env, ledger_id), expected_total_supply);
+    assert_eq!(env.icrc1_total_supply(), expected_total_supply);
 
     // withdraw cycles from main account
-    let withdraw_receiver_balance = env.cycle_balance(withdraw_receiver);
+    let withdraw_receiver_balance = env.state_machine.cycle_balance(withdraw_receiver);
     let withdraw_amount = 500_000_000_u128;
-    let _withdraw_idx = withdraw(
-        env,
-        ledger_id,
-        user_main_account,
-        WithdrawArgs {
-            from_subaccount: None,
-            to: withdraw_receiver,
-            created_at_time: None,
-            amount: Nat::from(withdraw_amount),
-        },
-    )
-    .unwrap();
+    let _withdraw_idx = env
+        .withdraw(
+            user_main_account,
+            WithdrawArgs {
+                from_subaccount: None,
+                to: withdraw_receiver,
+                created_at_time: None,
+                amount: Nat::from(withdraw_amount),
+            },
+        )
+        .unwrap();
     assert_eq!(
         withdraw_receiver_balance + withdraw_amount,
-        env.cycle_balance(withdraw_receiver)
+        env.state_machine.cycle_balance(withdraw_receiver)
     );
     assert_eq!(
-        balance_of(env, ledger_id, user_main_account),
+        env.icrc1_balance_of(user_main_account),
         1_000_000_000 - withdraw_amount - FEE
     );
     expected_total_supply -= withdraw_amount + FEE;
-    assert_eq!(total_supply(env, ledger_id), expected_total_supply);
+    assert_eq!(env.icrc1_total_supply(), expected_total_supply);
 
     // withdraw cycles from subaccount
-    let withdraw_receiver_balance = env.cycle_balance(withdraw_receiver);
+    let withdraw_receiver_balance = env.state_machine.cycle_balance(withdraw_receiver);
     let withdraw_amount = 100_000_000_u128;
-    let _withdraw_idx = withdraw(
-        env,
-        ledger_id,
-        user_subaccount_1,
-        WithdrawArgs {
-            from_subaccount: Some(*user_subaccount_1.effective_subaccount()),
-            to: withdraw_receiver,
-            created_at_time: None,
-            amount: Nat::from(withdraw_amount),
-        },
-    )
-    .unwrap();
+    let _withdraw_idx = env
+        .withdraw(
+            user_subaccount_1,
+            WithdrawArgs {
+                from_subaccount: Some(*user_subaccount_1.effective_subaccount()),
+                to: withdraw_receiver,
+                created_at_time: None,
+                amount: Nat::from(withdraw_amount),
+            },
+        )
+        .unwrap();
     assert_eq!(
         withdraw_receiver_balance + withdraw_amount,
-        env.cycle_balance(withdraw_receiver)
+        env.state_machine.cycle_balance(withdraw_receiver)
     );
     assert_eq!(
-        balance_of(env, ledger_id, user_subaccount_1),
+        env.icrc1_balance_of(user_subaccount_1),
         1_000_000_000 - withdraw_amount - FEE
     );
     expected_total_supply -= withdraw_amount + FEE;
-    assert_eq!(total_supply(env, ledger_id), expected_total_supply);
+    assert_eq!(env.icrc1_total_supply(), expected_total_supply);
 
     // withdraw cycles from subaccount with created_at_time set
-    let now = env
-        .time()
-        .duration_since(SystemTime::UNIX_EPOCH)
-        .unwrap()
-        .as_nanos() as u64;
-    let withdraw_receiver_balance = env.cycle_balance(withdraw_receiver);
+    let now = env.nanos_since_epoch_u64();
+    let withdraw_receiver_balance = env.state_machine.cycle_balance(withdraw_receiver);
     let withdraw_amount = 300_000_000_u128;
-    let _withdraw_idx = withdraw(
-        env,
-        ledger_id,
-        user_subaccount_3,
-        WithdrawArgs {
-            from_subaccount: Some(*user_subaccount_3.effective_subaccount()),
-            to: withdraw_receiver,
-            created_at_time: Some(now),
-            amount: Nat::from(withdraw_amount),
-        },
-    )
-    .unwrap();
+    let _withdraw_idx = env
+        .withdraw(
+            user_subaccount_3,
+            WithdrawArgs {
+                from_subaccount: Some(*user_subaccount_3.effective_subaccount()),
+                to: withdraw_receiver,
+                created_at_time: Some(now),
+                amount: Nat::from(withdraw_amount),
+            },
+        )
+        .unwrap();
     assert_eq!(
         withdraw_receiver_balance + withdraw_amount,
-        env.cycle_balance(withdraw_receiver)
+        env.state_machine.cycle_balance(withdraw_receiver)
     );
     assert_eq!(
-        balance_of(env, ledger_id, user_subaccount_3),
+        env.icrc1_balance_of(user_subaccount_3),
         1_000_000_000 - withdraw_amount - FEE
     );
     expected_total_supply -= withdraw_amount + FEE;
-    assert_eq!(total_supply(env, ledger_id), expected_total_supply);
+    assert_eq!(env.icrc1_total_supply(), expected_total_supply);
 }
 
 // A test to check that `DuplicateError` is returned on a duplicate `withdraw` request
@@ -392,46 +549,36 @@ fn test_withdraw_flow() {
 // to execute it a second time
 #[test]
 fn test_withdraw_duplicate() {
-    let env = &new_state_machine();
-    let ledger_id = install_ledger(env);
-    let depositor_id = install_depositor(env, ledger_id);
-    let user_main_account = Account {
-        owner: Principal::from_slice(&[1]),
-        subaccount: None,
-    };
-    let withdraw_receiver = env.create_canister(None);
+    let env = TestEnv::setup();
+    let user_main_account = account(1, None);
+    let withdraw_receiver = env.state_machine.create_canister(None);
 
     // make deposits to the user and check the result
-    let deposit_res = deposit(env, depositor_id, user_main_account, 1_000_000_000, None);
+    let deposit_res = env.deposit(user_main_account, 1_000_000_000, None);
     assert_eq!(deposit_res.block_index, 0_u128);
     assert_eq!(deposit_res.balance, 1_000_000_000_u128);
 
-    let now = env
-        .time()
-        .duration_since(SystemTime::UNIX_EPOCH)
-        .unwrap()
-        .as_nanos() as u64;
+    let now = env.nanos_since_epoch_u64();
     // withdraw cycles from main account
-    let withdraw_receiver_balance = env.cycle_balance(withdraw_receiver);
+    let withdraw_receiver_balance = env.state_machine.cycle_balance(withdraw_receiver);
     let withdraw_amount = 900_000_000_u128;
-    let withdraw_idx = withdraw(
-        env,
-        ledger_id,
-        user_main_account,
-        WithdrawArgs {
-            from_subaccount: None,
-            to: withdraw_receiver,
-            created_at_time: Some(now),
-            amount: Nat::from(withdraw_amount),
-        },
-    )
-    .unwrap();
+    let withdraw_idx = env
+        .withdraw(
+            user_main_account,
+            WithdrawArgs {
+                from_subaccount: None,
+                to: withdraw_receiver,
+                created_at_time: Some(now),
+                amount: Nat::from(withdraw_amount),
+            },
+        )
+        .unwrap();
     assert_eq!(
         withdraw_receiver_balance + withdraw_amount,
-        env.cycle_balance(withdraw_receiver)
+        env.state_machine.cycle_balance(withdraw_receiver)
     );
     assert_eq!(
-        balance_of(env, ledger_id, user_main_account),
+        env.icrc1_balance_of(user_main_account),
         1_000_000_000 - withdraw_amount - FEE
     );
 
@@ -439,9 +586,7 @@ fn test_withdraw_duplicate() {
         WithdrawError::Duplicate {
             duplicate_of: withdraw_idx
         },
-        withdraw(
-            env,
-            ledger_id,
+        env.withdraw(
             user_main_account,
             WithdrawArgs {
                 from_subaccount: None,
@@ -456,102 +601,96 @@ fn test_withdraw_duplicate() {
 
 #[test]
 fn test_withdraw_fails() {
-    let env = &new_state_machine();
-    let ledger_id = install_ledger(env);
-    let depositor_id = install_depositor(env, ledger_id);
-    let user = Account {
-        owner: Principal::from_slice(&[1]),
-        subaccount: None,
-    };
+    let env = TestEnv::setup();
+    let user = account(1, None);
 
     // make the first deposit to the user and check the result
-    let deposit_res = deposit(env, depositor_id, user, 1_000_000_000_000, None);
+    let deposit_res = env.deposit(user, 1_000_000_000_000, None);
     assert_eq!(deposit_res.block_index, Nat::from(0_u128));
     assert_eq!(deposit_res.balance, 1_000_000_000_000_u128);
 
     // withdraw more than available
-    let balance_before_attempt = balance_of(env, ledger_id, user);
-    let withdraw_result = withdraw(
-        env,
-        ledger_id,
-        user,
-        WithdrawArgs {
-            from_subaccount: None,
-            to: depositor_id,
-            created_at_time: None,
-            amount: Nat::from(u128::MAX),
-        },
-    )
-    .unwrap_err();
+    let balance_before_attempt = env.icrc1_balance_of(user);
+    let withdraw_result = env
+        .withdraw(
+            user,
+            WithdrawArgs {
+                from_subaccount: None,
+                to: env.depositor_id,
+                created_at_time: None,
+                amount: Nat::from(u128::MAX),
+            },
+        )
+        .unwrap_err();
     assert!(matches!(
         withdraw_result,
         WithdrawError::InsufficientFunds { balance } if balance == 1_000_000_000_000_u128
     ));
-    assert_eq!(balance_before_attempt, balance_of(env, ledger_id, user));
+    assert_eq!(balance_before_attempt, env.icrc1_balance_of(user));
     let mut expected_total_supply = 1_000_000_000_000;
-    assert_eq!(total_supply(env, ledger_id), expected_total_supply,);
+    assert_eq!(env.icrc1_total_supply(), expected_total_supply);
 
     // withdraw from empty subaccount
-    let withdraw_result = withdraw(
-        env,
-        ledger_id,
-        user,
-        WithdrawArgs {
-            from_subaccount: Some([5; 32]),
-            to: depositor_id,
-            created_at_time: None,
-            amount: Nat::from(100_000_000_u128),
-        },
-    )
-    .unwrap_err();
+    let withdraw_result = env
+        .withdraw(
+            user,
+            WithdrawArgs {
+                from_subaccount: Some([5; 32]),
+                to: env.depositor_id,
+                created_at_time: None,
+                amount: Nat::from(100_000_000_u128),
+            },
+        )
+        .unwrap_err();
     assert!(matches!(
         withdraw_result,
         WithdrawError::InsufficientFunds { balance } if balance == 0_u128
     ));
-    assert_eq!(total_supply(env, ledger_id), expected_total_supply,);
+    assert_eq!(env.icrc1_total_supply(), expected_total_supply,);
 
     // withdraw cycles to user instead of canister
-    let balance_before_attempt = balance_of(env, ledger_id, user);
-    let self_authenticating_principal = candid::Principal::from_text(
-        "luwgt-ouvkc-k5rx5-xcqkq-jx5hm-r2rj2-ymqjc-pjvhb-kij4p-n4vms-gqe",
-    )
-    .unwrap();
-    let withdraw_result = withdraw(
-        env,
-        ledger_id,
-        user,
-        WithdrawArgs {
-            from_subaccount: None,
-            to: self_authenticating_principal,
-            created_at_time: None,
-            amount: Nat::from(500_000_000_u128),
-        },
-    )
-    .unwrap_err();
+    let balance_before_attempt = env.icrc1_balance_of(user);
+    let self_authenticating_principal =
+        Principal::from_text("luwgt-ouvkc-k5rx5-xcqkq-jx5hm-r2rj2-ymqjc-pjvhb-kij4p-n4vms-gqe")
+            .unwrap();
+    let withdraw_result = env
+        .withdraw(
+            user,
+            WithdrawArgs {
+                from_subaccount: None,
+                to: self_authenticating_principal,
+                created_at_time: None,
+                amount: Nat::from(500_000_000_u128),
+            },
+        )
+        .unwrap_err();
     assert!(matches!(
         withdraw_result,
         WithdrawError::InvalidReceiver { receiver } if receiver == self_authenticating_principal
     ));
-    assert_eq!(balance_before_attempt, balance_of(env, ledger_id, user));
-    assert_eq!(total_supply(env, ledger_id), expected_total_supply,);
+    assert_eq!(balance_before_attempt, env.icrc1_balance_of(user));
+    assert_eq!(env.icrc1_total_supply(), expected_total_supply);
 
     // withdraw cycles to deleted canister
-    let balance_before_attempt = balance_of(env, ledger_id, user);
-    let deleted_canister = env.create_canister(None);
-    env.stop_canister(deleted_canister, None).unwrap();
-    env.delete_canister(deleted_canister, None).unwrap();
-    let withdraw_result = withdraw(
-        env,
-        ledger_id,
-        user,
-        WithdrawArgs {
-            from_subaccount: None,
-            to: deleted_canister,
-            created_at_time: None,
-            amount: Nat::from(500_000_000_u128),
-        },
-    )
-    .unwrap_err();
+    let balance_before_attempt = env.icrc1_balance_of(user);
+    let deleted_canister = env.state_machine.create_canister(None);
+    env.state_machine
+        .stop_canister(deleted_canister, None)
+        .unwrap();
+    env.state_machine
+        .delete_canister(deleted_canister, None)
+        .unwrap();
+    let withdraw_result = env
+        .withdraw(
+            user,
+            WithdrawArgs {
+                from_subaccount: None,
+                to: deleted_canister,
+                created_at_time: None,
+                amount: Nat::from(500_000_000_u128),
+            },
+        )
+        .unwrap_err();
     assert!(matches!(
         withdraw_result,
         WithdrawError::FailedToWithdraw {
@@ -559,121 +698,98 @@ fn test_withdraw_fails() {
             ..
         }
     ));
-    assert_eq!(
-        balance_before_attempt - FEE,
-        balance_of(env, ledger_id, user)
-    );
+    assert_eq!(balance_before_attempt - FEE, env.icrc1_balance_of(user));
     expected_total_supply -= FEE;
-    assert_eq!(total_supply(env, ledger_id), expected_total_supply,);
+    assert_eq!(env.icrc1_total_supply(), expected_total_supply,);
 
     // user keeps the cycles if they don't have enough balance to pay the fee
-    let user_2 = Account {
-        owner: Principal::from_slice(&[2]),
-        subaccount: None,
-    };
-    deposit(env, depositor_id, user_2, FEE + 1, None);
-    withdraw(
-        env,
-        ledger_id,
-        user_2,
-        WithdrawArgs {
-            from_subaccount: None,
-            to: depositor_id,
-            created_at_time: None,
-            amount: Nat::from(u128::MAX),
-        },
-    )
-    .unwrap_err();
-    assert_eq!(FEE + 1, balance_of(env, ledger_id, user_2));
-    withdraw(
-        env,
-        ledger_id,
-        user_2,
-        WithdrawArgs {
-            from_subaccount: None,
-            to: depositor_id,
-            created_at_time: None,
-            amount: Nat::from(u128::MAX),
-        },
-    )
-    .unwrap_err();
-    assert_eq!(FEE + 1, balance_of(env, ledger_id, user_2));
+    let user_2 = account(2, None);
+    let _deposit_res = env.deposit(user_2, FEE + 1, None);
+    let _withdraw_res = env
+        .withdraw(
+            user_2,
+            WithdrawArgs {
+                from_subaccount: None,
+                to: env.depositor_id,
+                created_at_time: None,
+                amount: Nat::from(u128::MAX),
+            },
+        )
+        .unwrap_err();
+    assert_eq!(FEE + 1, env.icrc1_balance_of(user_2));
+    let _withdraw_res = env
+        .withdraw(
+            user_2,
+            WithdrawArgs {
+                from_subaccount: None,
+                to: env.depositor_id,
+                created_at_time: None,
+                amount: Nat::from(u128::MAX),
+            },
+        )
+        .unwrap_err();
+    assert_eq!(FEE + 1, env.icrc1_balance_of(user_2));
 
     // test withdraw deduplication
-    deposit(env, depositor_id, user_2, FEE * 3, None);
-    let created_at_time = env.time().duration_since(UNIX_EPOCH).unwrap().as_nanos() as u64;
+    let _deposit_res = env.deposit(user_2, FEE * 3, None);
+    let created_at_time = env.nanos_since_epoch_u64();
     let args = WithdrawArgs {
         from_subaccount: None,
-        to: depositor_id,
+        to: env.depositor_id,
         created_at_time: Some(created_at_time),
         amount: Nat::from(FEE),
     };
-    let duplicate_of = withdraw(env, ledger_id, user_2, args.clone()).unwrap();
+    let duplicate_of = env.withdraw_or_trap(user_2, args.clone());
     // the same withdraw should fail because created_at_time is set and the args are the same
     assert_eq!(
-        withdraw(env, ledger_id, user_2, args),
+        env.withdraw(user_2, args),
         Err(WithdrawError::Duplicate { duplicate_of })
     );
 }
 
-fn system_time_to_nanos(t: SystemTime) -> u64 {
-    t.duration_since(SystemTime::UNIX_EPOCH).unwrap().as_nanos() as u64
-}
-
 #[test]
 fn test_approve_max_allowance_size() {
-    let env = &new_state_machine();
-    let ledger_id = install_ledger(env);
-    let depositor_id = install_depositor(env, ledger_id);
-    let from = Account {
-        owner: Principal::from_slice(&[0]),
-        subaccount: None,
-    };
-    let spender = Account {
-        owner: Principal::from_slice(&[1]),
-        subaccount: None,
-    };
+    let env = TestEnv::setup();
+    let from = account(0, None);
+    let spender = account(1, None);
 
     // Deposit funds
     assert_eq!(
-        deposit(env, depositor_id, from, 1_000_000_000, None).balance,
+        env.deposit(from, 1_000_000_000, None).balance,
         1_000_000_000_u128
     );
 
     // Largest possible allowance in terms of size in bytes - max amount and expiration
-    let block_index = approve(
-        env,
-        ledger_id,
-        from,
-        spender,
-        u128::MAX,
-        None,
-        Some(u64::MAX),
-    )
-    .expect("approve failed");
+    let block_index = env
+        .icrc2_approve(
+            from.owner,
+            ApproveArgs {
+                from_subaccount: from.subaccount,
+                spender,
+                amount: Nat::from(u128::MAX),
+                created_at_time: None,
+                expected_allowance: None,
+                expires_at: Some(u64::MAX),
+                fee: None,
+                memo: None,
+            },
+        )
+        .expect("approve failed");
     assert_eq!(block_index, 1_u128);
-    let allowance = get_allowance(env, ledger_id, from, spender);
+    let allowance = env.icrc2_allowance(from, spender);
     assert_eq!(allowance.allowance, Nat::from(u128::MAX));
     assert_eq!(allowance.expires_at, Some(u64::MAX));
-    assert_eq!(
-        balance_of(env, ledger_id, from),
-        Nat::from(1_000_000_000 - FEE)
-    );
+    assert_eq!(env.icrc1_balance_of(from), Nat::from(1_000_000_000 - FEE));
 }
 
 #[test]
 fn test_approve_self() {
-    let env = &new_state_machine();
-    let ledger_id = install_ledger(env);
-    let depositor_id = install_depositor(env, ledger_id);
-    let from = Account {
-        owner: Principal::from_slice(&[0]),
-        subaccount: None,
-    };
+    let env = TestEnv::setup();
+    let from = account(0, None);
 
     // Deposit funds
     assert_eq!(
-        deposit(env, depositor_id, from, 1_000_000_000, None).balance,
+        env.deposit(from, 1_000_000_000, None).balance,
         1_000_000_000_u128
     );
 
@@ -688,8 +804,9 @@ fn test_approve_self() {
         created_at_time: None,
     };
     let err = env
+        .state_machine
         .update_call(
-            ledger_id,
+            env.ledger_id,
             from.owner,
             "icrc2_approve",
             Encode!(&args).unwrap(),
@@ -697,27 +814,19 @@ fn test_approve_self() {
         .unwrap_err();
     assert_eq!(err.code, ErrorCode::CanisterCalledTrap);
     assert!(err.description.ends_with("self approval is not allowed"));
-    assert_eq!(balance_of(env, ledger_id, from), 1_000_000_000);
-    assert_eq!(total_supply(env, ledger_id), 1_000_000_000);
+    assert_eq!(env.icrc1_balance_of(from), 1_000_000_000);
+    assert_eq!(env.icrc1_total_supply(), 1_000_000_000);
 }
 
 #[test]
 fn test_approve_cap() {
-    let env = &new_state_machine();
-    let ledger_id = install_ledger(env);
-    let depositor_id = install_depositor(env, ledger_id);
-    let from = Account {
-        owner: Principal::from_slice(&[0]),
-        subaccount: None,
-    };
-    let spender = Account {
-        owner: Principal::from_slice(&[1]),
-        subaccount: None,
-    };
+    let env = TestEnv::setup();
+    let from = account(0, None);
+    let spender = account(1, None);
 
     // Deposit funds
     assert_eq!(
-        deposit(env, depositor_id, from, 1_000_000_000, None).balance,
+        env.deposit(from, 1_000_000_000, None).balance,
         1_000_000_000_u128
     );
 
@@ -734,50 +843,30 @@ fn test_approve_cap() {
         memo: None,
         created_at_time: None,
     };
-    env.update_call(
-        ledger_id,
-        from.owner,
-        "icrc2_approve",
-        Encode!(&args).unwrap(),
-    )
-    .unwrap();
-    let allowance = get_allowance(env, ledger_id, from, spender);
+    let _approve_res = env
+        .icrc2_approve(from.owner, args)
+        .expect("Unable to approve");
+    let allowance = env.icrc2_allowance(from, spender);
     assert_eq!(allowance.allowance, Nat::from(u128::MAX));
     assert_eq!(allowance.expires_at, None);
-    assert_eq!(
-        balance_of(env, ledger_id, from),
-        Nat::from(1_000_000_000 - FEE)
-    );
+    assert_eq!(env.icrc1_balance_of(from), Nat::from(1_000_000_000 - FEE));
 }
 
 // A test to check that `DuplicateError` is returned on a duplicate `approve` request
 // and not `UnexpectedAllowanceError` if `expected_allowance` is set
 #[test]
 fn test_approve_duplicate() {
-    use icrc_ledger_types::icrc2::approve::ApproveError;
-    let env = &new_state_machine();
-    let ledger_id = install_ledger(env);
-    let depositor_id = install_depositor(env, ledger_id);
-    let from = Account {
-        owner: Principal::from_slice(&[0]),
-        subaccount: None,
-    };
-    let spender = Account {
-        owner: Principal::from_slice(&[1]),
-        subaccount: None,
-    };
+    let env = TestEnv::setup();
+    let from = account(0, None);
+    let spender = account(1, None);
 
     // Deposit funds
     assert_eq!(
-        deposit(env, depositor_id, from, 1_000_000_000, None).balance,
+        env.deposit(from, 1_000_000_000, None).balance,
         1_000_000_000u128
     );
 
-    let now = env
-        .time()
-        .duration_since(SystemTime::UNIX_EPOCH)
-        .unwrap()
-        .as_nanos() as u64;
+    let now = env.nanos_since_epoch_u64();
     let args = ApproveArgs {
         from_subaccount: None,
         spender,
@@ -788,216 +877,187 @@ fn test_approve_duplicate() {
         memo: None,
         created_at_time: Some(now),
     };
-    env.update_call(
-        ledger_id,
-        from.owner,
-        "icrc2_approve",
-        Encode!(&args).unwrap(),
-    )
-    .unwrap();
-    let allowance = get_allowance(env, ledger_id, from, spender);
+
+    // first approve should work
+    let duplicate_of = env
+        .icrc2_approve(from.owner, args.clone())
+        .expect("Unable to approve");
+    let allowance = env.icrc2_allowance(from, spender);
     assert_eq!(allowance.allowance, Nat::from(100u128));
     assert_eq!(allowance.expires_at, None);
+    assert_eq!(env.icrc1_balance_of(from), Nat::from(1_000_000_000 - FEE));
+
+    // second approve should fail with deduplicate
     assert_eq!(
-        balance_of(env, ledger_id, from),
-        Nat::from(1_000_000_000 - FEE)
-    );
-
-    // re-submit should error with duplicate
-    env.update_call(
-        ledger_id,
-        from.owner,
-        "icrc2_approve",
-        Encode!(&args).unwrap(),
-    )
-    .unwrap();
-
-    let result = if let WasmResult::Reply(res) = env
-        .update_call(
-            ledger_id,
-            from.owner,
-            "icrc2_approve",
-            Encode!(&args).unwrap(),
-        )
-        .unwrap()
-    {
-        Decode!(&res, Result<Nat, ApproveError>).unwrap()
-    } else {
-        panic!("icrc2_approve rejected")
-    };
-
-    assert_eq!(
-        result,
-        Err(ApproveError::Duplicate {
-            duplicate_of: Nat::from(1u128)
-        })
+        env.icrc2_approve(from.owner, args),
+        Err(ApproveError::Duplicate { duplicate_of })
     );
 }
 
 #[test]
 fn test_approval_expiring() {
-    let env = &new_state_machine();
-    let ledger_id = install_ledger(env);
-    let depositor_id = install_depositor(env, ledger_id);
-    let from = Account {
-        owner: Principal::from_slice(&[0]),
-        subaccount: None,
-    };
-    let spender1 = Account {
-        owner: Principal::from_slice(&[1]),
-        subaccount: None,
-    };
-    let spender2 = Account {
-        owner: Principal::from_slice(&[2]),
-        subaccount: None,
-    };
-    let spender3 = Account {
-        owner: Principal::from_slice(&[3]),
-        subaccount: None,
-    };
+    let env = TestEnv::setup();
+    let from = account(0, None);
+    let spender1 = account(1, None);
+    let spender2 = account(2, None);
+    let spender3 = account(3, None);
 
     // Deposit funds
     assert_eq!(
-        deposit(env, depositor_id, from, 1_000_000_000, None).balance,
+        env.deposit(from, 1_000_000_000, None).balance,
         1_000_000_000_u128
     );
 
     // First approval expiring 1 hour from now.
-    let expiration = system_time_to_nanos(env.time()) + Duration::from_secs(3600).as_nanos() as u64;
-    let block_index = approve(
-        env,
-        ledger_id,
-        from,
-        spender1,
-        100_000_000_u128,
-        None,
-        Some(expiration),
-    )
-    .expect("approve failed");
+    let expiration = env.nanos_since_epoch_u64() + Duration::from_secs(3600).as_nanos() as u64;
+    let block_index = env
+        .icrc2_approve(
+            from.owner,
+            ApproveArgs {
+                from_subaccount: from.subaccount,
+                spender: spender1,
+                amount: Nat::from(100_000_000u32),
+                memo: None,
+                expires_at: Some(expiration),
+                expected_allowance: None,
+                fee: None,
+                created_at_time: None,
+            },
+        )
+        .expect("approve failed");
     assert_eq!(block_index, 1_u128);
-    let allowance = get_allowance(env, ledger_id, from, spender1);
+    // TODO: check the block
+    let allowance = env.icrc2_allowance(from, spender1);
     assert_eq!(allowance.allowance, Nat::from(100_000_000_u128));
     assert_eq!(allowance.expires_at, Some(expiration));
 
     // Second approval expiring 3 hour from now.
     let expiration_3h =
-        system_time_to_nanos(env.time()) + Duration::from_secs(3 * 3600).as_nanos() as u64;
-    let block_index = approve(
-        env,
-        ledger_id,
-        from,
-        spender2,
-        200_000_000_u128,
-        None,
-        Some(expiration_3h),
-    )
-    .expect("approve failed");
+        env.nanos_since_epoch_u64() + Duration::from_secs(3 * 3600).as_nanos() as u64;
+    let block_index = env
+        .icrc2_approve(
+            from.owner,
+            ApproveArgs {
+                from_subaccount: from.subaccount,
+                spender: spender2,
+                amount: Nat::from(200_000_000u32),
+                memo: None,
+                expires_at: Some(expiration_3h),
+                expected_allowance: None,
+                fee: None,
+                created_at_time: None,
+            },
+        )
+        .expect("approve failed");
     assert_eq!(block_index, 2_u128);
-    let allowance = get_allowance(env, ledger_id, from, spender2);
+    // TODO: check the block
+    let allowance = env.icrc2_allowance(from, spender2);
     assert_eq!(allowance.allowance, Nat::from(200_000_000_u128));
     assert_eq!(allowance.expires_at, Some(expiration_3h));
 
     // Test expired approval pruning, advance time 2 hours.
-    env.advance_time(Duration::from_secs(2 * 3600));
-    env.tick();
+    env.state_machine
+        .advance_time(Duration::from_secs(2 * 3600));
+    env.state_machine.tick();
 
     // Add additional approval to trigger expired approval pruning
-    approve(
-        env,
-        ledger_id,
-        from,
-        spender3,
-        300_000_000_u128,
-        None,
-        Some(expiration_3h),
-    )
-    .expect("approve failed");
-    let allowance = get_allowance(env, ledger_id, from, spender3);
+    env.icrc2_approve_or_trap(
+        from.owner,
+        ApproveArgs {
+            from_subaccount: from.subaccount,
+            spender: spender3,
+            amount: Nat::from(300_000_000u32),
+            memo: None,
+            expires_at: Some(expiration_3h),
+            expected_allowance: None,
+            fee: None,
+            created_at_time: None,
+        },
+    );
+    // TODO: check the block
+    let allowance = env.icrc2_allowance(from, spender3);
     assert_eq!(allowance.allowance, Nat::from(300_000_000_u128));
     assert_eq!(allowance.expires_at, Some(expiration_3h));
 
-    let allowance = get_allowance(env, ledger_id, from, spender1);
+    let allowance = env.icrc2_allowance(from, spender1);
     assert_eq!(allowance.allowance, Nat::from(0_u128));
     assert_eq!(allowance.expires_at, None);
-    let allowance = get_allowance(env, ledger_id, from, spender2);
+    let allowance = env.icrc2_allowance(from, spender2);
     assert_eq!(allowance.allowance, Nat::from(200_000_000_u128));
     assert_eq!(allowance.expires_at, Some(expiration_3h));
 
     // Should not be able to approve from/to a denied principal
     for owner in [Principal::anonymous(), Principal::management_canister()] {
-        approve(
-            env,
-            ledger_id,
-            Account::from(owner),
-            spender1,
-            100_000_000u128,
-            None,
-            None,
+        env.icrc2_approve(
+            owner,
+            ApproveArgs {
+                from_subaccount: None,
+                spender: spender1,
+                amount: Nat::from(100_000_000u32),
+                memo: None,
+                expires_at: None,
+                expected_allowance: None,
+                fee: None,
+                created_at_time: None,
+            },
         )
-        .unwrap_err();
-        approve(
-            env,
-            ledger_id,
-            from,
-            Account::from(owner),
-            100_000_000u128,
-            None,
-            None,
+        .unwrap_err(); // TODO: check the error
+        env.icrc2_approve(
+            owner,
+            ApproveArgs {
+                from_subaccount: None,
+                spender: spender2,
+                amount: Nat::from(100_000_000u32),
+                memo: None,
+                expires_at: None,
+                expected_allowance: None,
+                fee: None,
+                created_at_time: None,
+            },
         )
-        .unwrap_err();
+        .unwrap_err(); // TODO: check the error
     }
 }
 
 #[test]
 fn test_basic_transfer() {
-    let env = &new_state_machine();
-    let ledger_id = install_ledger(env);
-    let depositor_id = install_depositor(env, ledger_id);
-    let user1 = Account {
-        owner: Principal::from_slice(&[1]),
-        subaccount: None,
-    };
-    let user2: Account = Account {
-        owner: Principal::from_slice(&[2]),
-        subaccount: None,
-    };
+    let env = TestEnv::setup();
+    let user1 = account(1, None);
+    let user2 = account(2, None);
     let deposit_amount = 1_000_000_000;
-    deposit(env, depositor_id, user1, deposit_amount, None);
-    let fee = fee(env, ledger_id);
+    let _deposit_res = env.deposit(user1, deposit_amount, None);
+    let fee = env.icrc1_fee();
     let mut expected_total_supply = deposit_amount;
 
     let transfer_amount = Nat::from(100_000_u128);
-    transfer(
-        env,
-        ledger_id,
-        user1.owner,
-        TransferArgs {
-            from_subaccount: None,
-            to: user2,
-            fee: None,
-            created_at_time: None,
-            memo: None,
-            amount: transfer_amount.clone(),
-        },
-    )
-    .unwrap();
+    let _block_idx = env
+        .icrc1_transfer(
+            user1.owner,
+            TransferArgs {
+                from_subaccount: None,
+                to: user2,
+                fee: None,
+                created_at_time: None,
+                memo: None,
+                amount: transfer_amount.clone(),
+            },
+        )
+        .expect("Unable to make transfer");
 
-    assert_eq!(balance_of(env, ledger_id, user2), transfer_amount.clone());
+    assert_eq!(env.icrc1_balance_of(user2), transfer_amount.clone());
     assert_eq!(
-        balance_of(env, ledger_id, user1),
-        Nat::from(deposit_amount) - fee.clone() - transfer_amount.clone()
+        env.icrc1_balance_of(user1),
+        Nat::from(deposit_amount) - fee - transfer_amount.clone()
     );
-    expected_total_supply -= fee.0.to_u128().unwrap();
-    assert_eq!(total_supply(env, ledger_id), expected_total_supply);
+    expected_total_supply -= fee;
+    assert_eq!(env.icrc1_total_supply(), expected_total_supply);
 
     // Should not be able to send back the full amount as the user2 cannot pay the fee
     assert_eq!(
-        TransferError::InsufficientFunds {
+        Err(TransferError::InsufficientFunds {
             balance: transfer_amount.clone()
-        },
-        transfer(
-            env,
-            ledger_id,
+        }),
+        env.icrc1_transfer(
             user2.owner,
             TransferArgs {
                 from_subaccount: None,
@@ -1008,18 +1068,15 @@ fn test_basic_transfer() {
                 amount: transfer_amount.clone(),
             },
         )
-        .unwrap_err()
     );
-    assert_eq!(total_supply(env, ledger_id), expected_total_supply);
+    assert_eq!(env.icrc1_total_supply(), expected_total_supply);
 
     // Should not be able to set a fee that is incorrect
     assert_eq!(
-        TransferError::BadFee {
-            expected_fee: fee.clone()
-        },
-        transfer(
-            env,
-            ledger_id,
+        Err(TransferError::BadFee {
+            expected_fee: Nat::from(fee)
+        }),
+        env.icrc1_transfer(
             user1.owner,
             TransferArgs {
                 from_subaccount: None,
@@ -1030,14 +1087,11 @@ fn test_basic_transfer() {
                 amount: transfer_amount.clone(),
             },
         )
-        .unwrap_err()
     );
 
     // Should not be able to transfer from a denied principal
     for owner in [Principal::anonymous(), Principal::management_canister()] {
-        transfer(
-            env,
-            ledger_id,
+        env.icrc1_transfer(
             owner,
             TransferArgs {
                 from_subaccount: None,
@@ -1050,9 +1104,7 @@ fn test_basic_transfer() {
         )
         .unwrap_err();
 
-        transfer(
-            env,
-            ledger_id,
+        env.icrc1_transfer(
             user1.owner,
             TransferArgs {
                 from_subaccount: None,
@@ -1065,156 +1117,92 @@ fn test_basic_transfer() {
         )
         .unwrap_err();
 
-        transfer_from(env, ledger_id, user1, user2, Account::from(owner), 0).unwrap_err();
+        env.icrc2_transfer_from(
+            owner,
+            TransferFromArgs {
+                spender_subaccount: None,
+                from: user1,
+                to: user2,
+                amount: Nat::from(0u32),
+                fee: None,
+                memo: None,
+                created_at_time: None,
+            },
+        )
+        .unwrap_err();
     }
 }
 
 #[test]
 fn test_deduplication() {
-    let env = &new_state_machine();
-    let ledger_id = install_ledger(env);
-    let depositor_id = install_depositor(env, ledger_id);
-    let user1 = Account {
-        owner: Principal::from_slice(&[1]),
-        subaccount: None,
-    };
-    let user2: Account = Account {
-        owner: Principal::from_slice(&[2]),
-        subaccount: None,
-    };
+    let env = TestEnv::setup();
+    let user1 = account(1, None);
+    let user2 = account(2, None);
     let deposit_amount = 1_000_000_000;
-    deposit(env, depositor_id, user1, deposit_amount, None);
+    let _deposit_res = env.deposit(user1, deposit_amount, None);
     let transfer_amount = Nat::from(100_000_u128);
 
-    // If created_at_time is not set, the same transaction should be able to be sent multiple times
-    transfer(
-        env,
-        ledger_id,
-        user1.owner,
-        TransferArgs {
-            from_subaccount: None,
-            to: user2,
-            fee: None,
-            created_at_time: None,
-            memo: None,
-            amount: transfer_amount.clone(),
-        },
-    )
-    .unwrap();
+    let args = TransferArgs {
+        from_subaccount: None,
+        to: user2,
+        fee: None,
+        created_at_time: None,
+        memo: None,
+        amount: transfer_amount.clone(),
+    };
 
-    transfer(
-        env,
-        ledger_id,
-        user1.owner,
-        TransferArgs {
-            from_subaccount: None,
-            to: user2,
-            fee: None,
-            created_at_time: None,
-            memo: None,
-            amount: transfer_amount.clone(),
-        },
-    )
-    .unwrap();
+    // If created_at_time is not set, the same transaction should be able to be sent multiple times
+    let _block_index = env.icrc1_transfer_or_trap(user1.owner, args.clone());
+    let _block_index = env.icrc1_transfer_or_trap(user1.owner, args.clone());
 
     // Should not be able commit a transaction that was created in the future
-    let mut now = env
-        .time()
-        .duration_since(SystemTime::UNIX_EPOCH)
-        .unwrap()
-        .as_nanos() as u64;
+    let now = env.nanos_since_epoch_u64();
     assert_eq!(
-        TransferError::CreatedInFuture { ledger_time: now },
-        transfer(
-            env,
-            ledger_id,
+        Err(TransferError::CreatedInFuture { ledger_time: now }),
+        env.icrc1_transfer(
             user1.owner,
             TransferArgs {
-                from_subaccount: None,
-                to: user1,
-                fee: None,
                 created_at_time: Some(u64::MAX),
-                memo: None,
-                amount: transfer_amount.clone(),
+                ..args.clone()
             },
         )
-        .unwrap_err()
     );
 
     // Should be able to make a transfer when created_at_time is valid
-    let tx: Nat = transfer(
-        env,
-        ledger_id,
-        user1.owner,
-        TransferArgs {
-            from_subaccount: None,
-            to: user2,
-            fee: None,
-            created_at_time: Some(now),
-            memo: None,
-            amount: transfer_amount.clone(),
-        },
-    )
-    .unwrap();
+    let args = TransferArgs {
+        created_at_time: Some(now),
+        ..args
+    };
+    let block_index = env.icrc1_transfer_or_trap(user1.owner, args.clone());
 
     // Should not be able send the same transfer twice if created_at_time is set
     assert_eq!(
-        TransferError::Duplicate { duplicate_of: tx },
-        transfer(
-            env,
-            ledger_id,
-            user1.owner,
-            TransferArgs {
-                from_subaccount: None,
-                to: user2,
-                fee: None,
-                created_at_time: Some(now),
-                memo: None,
-                amount: transfer_amount.clone(),
-            },
-        )
-        .unwrap_err()
+        Err(TransferError::Duplicate {
+            duplicate_of: block_index
+        }),
+        env.icrc1_transfer(user1.owner, args.clone())
     );
 
     // Setting a different memo field should result in no deduplication
-    transfer(
-        env,
-        ledger_id,
+    env.icrc1_transfer_or_trap(
         user1.owner,
         TransferArgs {
-            from_subaccount: None,
-            to: user2,
-            fee: None,
-            created_at_time: Some(now),
             memo: Some(Memo(ByteBuf::from(b"1234".to_vec()))),
-            amount: transfer_amount.clone(),
+            ..args.clone()
         },
-    )
-    .unwrap();
+    );
 
-    // Advance time so that the deduplication window is shifted
-    env.advance_time(Duration::from_secs(1));
-    now = env
-        .time()
-        .duration_since(SystemTime::UNIX_EPOCH)
-        .unwrap()
-        .as_nanos() as u64;
-
-    // Now the transfer which was deduplicated previously should be ok
-    transfer(
-        env,
-        ledger_id,
-        user1.owner,
-        TransferArgs {
-            from_subaccount: None,
-            to: user2,
-            fee: None,
-            created_at_time: Some(now),
-            memo: None,
-            amount: transfer_amount.clone(),
-        },
-    )
-    .unwrap();
+    // Setting a different created_at_time should result in no deduplication
+    env.state_machine.advance_time(Duration::from_secs(1));
+    let _block_index = env
+        .icrc1_transfer(
+            user1.owner,
+            TransferArgs {
+                created_at_time: Some(now + 1),
+                ..args
+            },
+        )
+        .unwrap();
 }
 
 // A test to check that `DuplicateError` is returned on a duplicate `transfer` request
@@ -1222,79 +1210,42 @@ fn test_deduplication() {
 // to execute it a second time
 #[test]
 fn test_deduplication_with_insufficient_funds() {
-    let env = &new_state_machine();
-    let ledger_id = install_ledger(env);
-    let depositor_id = install_depositor(env, ledger_id);
-    let user1 = Account {
-        owner: Principal::from_slice(&[1]),
-        subaccount: None,
-    };
-    let user2: Account = Account {
-        owner: Principal::from_slice(&[2]),
-        subaccount: None,
-    };
+    let env = TestEnv::setup();
+    let user1 = account(1, None);
+    let user2 = account(2, None);
     let deposit_amount = 1_000_000_000;
-    deposit(env, depositor_id, user1, deposit_amount, None);
-    let transfer_amount = Nat::from(600_000_000u128);
+    env.deposit(user1, deposit_amount, None);
 
-    let now = env
-        .time()
-        .duration_since(SystemTime::UNIX_EPOCH)
-        .unwrap()
-        .as_nanos() as u64;
+    let now = env.nanos_since_epoch_u64();
+    let args = TransferArgs {
+        from_subaccount: None,
+        to: user2,
+        fee: None,
+        created_at_time: Some(now),
+        memo: None,
+        amount: Nat::from(600_000_000u128),
+    };
     // Make a transfer with created_at_time set
-    let tx: Nat = transfer(
-        env,
-        ledger_id,
-        user1.owner,
-        TransferArgs {
-            from_subaccount: None,
-            to: user2,
-            fee: None,
-            created_at_time: Some(now),
-            memo: None,
-            amount: transfer_amount.clone(),
-        },
-    )
-    .unwrap();
+    let block_index = env.icrc1_transfer_or_trap(user1.owner, args.clone());
 
     // Should not be able send the same transfer twice if created_at_time is set
     assert_eq!(
-        TransferError::Duplicate { duplicate_of: tx },
-        transfer(
-            env,
-            ledger_id,
-            user1.owner,
-            TransferArgs {
-                from_subaccount: None,
-                to: user2,
-                fee: None,
-                created_at_time: Some(now),
-                memo: None,
-                amount: transfer_amount.clone(),
-            },
-        )
-        .unwrap_err()
+        Err(TransferError::Duplicate {
+            duplicate_of: block_index
+        }),
+        env.icrc1_transfer(user1.owner, args)
     );
 }
 
 #[test]
 fn test_pruning_transactions() {
-    let env = &new_state_machine();
-    let ledger_id = install_ledger(env);
-    let depositor_id = install_depositor(env, ledger_id);
-    let user1 = Account {
-        owner: Principal::from_slice(&[1]),
-        subaccount: None,
-    };
-    let user2 = Account {
-        owner: Principal::from_slice(&[2]),
-        subaccount: None,
-    };
+    let env = TestEnv::setup();
+    let user1 = account(1, None);
+    let user2 = account(2, None);
     let transfer_amount = Nat::from(100_000_u128);
 
     let check_tx_hashes = |length: u64, first_block: u64, last_block: u64| {
-        let tx_hashes = transaction_hashes(env, ledger_id);
+        let tx_hashes = env.transaction_hashes();
         let mut idxs: Vec<&u64> = tx_hashes.values().collect::<Vec<&u64>>();
         idxs.sort();
         assert_eq!(idxs.len() as u64, length);
@@ -1303,7 +1254,7 @@ fn test_pruning_transactions() {
     };
     let check_tx_timestamps =
         |length: u64, first_timestamp: (u64, u64), last_timestamp: (u64, u64)| {
-            let tx_timestamps = transaction_timestamps(env, ledger_id);
+            let tx_timestamps = env.transaction_timestamps();
             assert_eq!(
                 tx_timestamps.first_key_value().unwrap(),
                 (&first_timestamp, &())
@@ -1315,262 +1266,186 @@ fn test_pruning_transactions() {
             assert_eq!(tx_timestamps.len() as u64, length);
         };
 
-    let tx_hashes = transaction_hashes(env, ledger_id);
+    let tx_hashes = env.transaction_hashes();
     // There have not been any transactions. The transaction hashes log should be empty
     assert!(tx_hashes.is_empty());
 
     let deposit_amount = 100_000_000_000;
-    deposit(env, depositor_id, user1, deposit_amount, None);
+    env.deposit(user1, deposit_amount, None);
 
     // A deposit does not have a `created_at_time` argument and is therefore not recorded
-    let tx_hashes = transaction_hashes(env, ledger_id);
+    let tx_hashes = env.transaction_hashes();
     assert!(tx_hashes.is_empty());
 
     // Create a transfer where `created_at_time` is not set
-    transfer(
-        env,
-        ledger_id,
-        user1.owner,
-        TransferArgs {
-            from_subaccount: None,
-            to: user2,
-            fee: None,
-            created_at_time: None,
-            memo: None,
-            amount: transfer_amount.clone(),
-        },
-    )
-    .unwrap();
+    let _block_index = env
+        .icrc1_transfer(
+            user1.owner,
+            TransferArgs {
+                from_subaccount: None,
+                to: user2,
+                fee: None,
+                created_at_time: None,
+                memo: None,
+                amount: transfer_amount.clone(),
+            },
+        )
+        .unwrap();
 
     // There should not be an entry for deduplication
-    let tx_hashes = transaction_hashes(env, ledger_id);
+    let tx_hashes = env.transaction_hashes();
     assert!(tx_hashes.is_empty());
 
-    let time = env
-        .time()
-        .duration_since(SystemTime::UNIX_EPOCH)
-        .unwrap()
-        .as_nanos() as u64;
+    let time = env.nanos_since_epoch_u64();
     // Create a transfer with `created_at_time` set
-    let transfer_idx_2 = transfer(
-        env,
-        ledger_id,
-        user1.owner,
-        TransferArgs {
-            from_subaccount: None,
-            to: user2,
-            fee: None,
-            created_at_time: Some(time),
-            memo: None,
-            amount: transfer_amount.clone(),
-        },
-    )
-    .unwrap()
-    .0
-    .to_u64()
-    .unwrap();
+    let block_index = env
+        .icrc1_transfer(
+            user1.owner,
+            TransferArgs {
+                from_subaccount: None,
+                to: user2,
+                fee: None,
+                created_at_time: Some(time),
+                memo: None,
+                amount: transfer_amount.clone(),
+            },
+        )
+        .unwrap()
+        .0
+        .to_u64()
+        .unwrap();
 
     // There should be one transaction appearing in the transaction queue for deduplication
-    check_tx_hashes(1, transfer_idx_2, transfer_idx_2);
-    check_tx_timestamps(1, (time, transfer_idx_2), (time, transfer_idx_2));
+    check_tx_hashes(1, block_index, block_index);
+    check_tx_timestamps(1, (time, block_index), (time, block_index));
 
     // Create another transaction with the same timestamp but a different hash
-    let transfer_idx_3 = transfer(
-        env,
-        ledger_id,
-        user1.owner,
-        TransferArgs {
-            from_subaccount: None,
-            to: user2,
-            fee: None,
-            created_at_time: Some(time),
-            memo: Some(Memo(ByteBuf::from(b"1234".to_vec()))),
-            amount: transfer_amount.clone(),
-        },
-    )
-    .unwrap()
-    .0
-    .to_u64()
-    .unwrap();
+    let transfer_idx_3 = env
+        .icrc1_transfer(
+            user1.owner,
+            TransferArgs {
+                from_subaccount: None,
+                to: user2,
+                fee: None,
+                created_at_time: Some(time),
+                memo: Some(Memo(ByteBuf::from(b"1234".to_vec()))),
+                amount: transfer_amount.clone(),
+            },
+        )
+        .unwrap()
+        .0
+        .to_u64()
+        .unwrap();
     // There are now two different tx hashes in 2 different transactions
-    check_tx_hashes(2, transfer_idx_2, transfer_idx_3);
-    check_tx_timestamps(2, (time, transfer_idx_2), (time, transfer_idx_3));
+    check_tx_hashes(2, block_index, transfer_idx_3);
+    check_tx_timestamps(2, (time, block_index), (time, transfer_idx_3));
 
     // Advance time to move the Transaction window
-    env.advance_time(Duration::from_nanos(
+    env.state_machine.advance_time(Duration::from_nanos(
         config::TRANSACTION_WINDOW.as_nanos() as u64
             + config::PERMITTED_DRIFT.as_nanos() as u64 * 2,
     ));
-    env.tick();
-    let time = env
-        .time()
-        .duration_since(SystemTime::UNIX_EPOCH)
-        .unwrap()
-        .as_nanos() as u64;
+    env.state_machine.tick();
+    let time = env.nanos_since_epoch_u64();
     // Create another transaction to trigger pruning
-    let transfer_idx_4 = transfer(
-        env,
-        ledger_id,
-        user1.owner,
-        TransferArgs {
-            from_subaccount: None,
-            to: user2,
-            fee: None,
-            created_at_time: Some(time),
-            memo: None,
-            amount: transfer_amount.clone(),
-        },
-    )
-    .unwrap()
-    .0
-    .to_u64()
-    .unwrap();
+    let block_index = env
+        .icrc1_transfer(
+            user1.owner,
+            TransferArgs {
+                from_subaccount: None,
+                to: user2,
+                fee: None,
+                created_at_time: Some(time),
+                memo: None,
+                amount: transfer_amount.clone(),
+            },
+        )
+        .unwrap()
+        .0
+        .to_u64()
+        .unwrap();
     // Transfers 2 and 3 should be removed leaving only one transfer left
-    check_tx_hashes(1, transfer_idx_4, transfer_idx_4);
-    check_tx_timestamps(1, (time, transfer_idx_4), (time, transfer_idx_4));
+    check_tx_hashes(1, block_index, block_index);
+    check_tx_timestamps(1, (time, block_index), (time, block_index));
 }
 
 #[test]
 fn test_total_supply_after_upgrade() {
-    let env = &new_state_machine();
-    let ledger_id = install_ledger(env);
-    let depositor_id = install_depositor(env, ledger_id);
-    let user1 = Account::from(Principal::from_slice(&[1]));
-    let user2 = Account::from(Principal::from_slice(&[2]));
+    let env = TestEnv::setup();
+    let user1 = account(1, None);
+    let user2 = account(2, None);
 
-    deposit(env, depositor_id, user1, 2_000_000_000, None);
-    deposit(env, depositor_id, user2, 3_000_000_000, None);
-    let fee = fee(env, ledger_id);
-    transfer(
-        env,
-        ledger_id,
-        user1.owner,
-        TransferArgs {
-            from_subaccount: None,
-            to: user2,
-            fee: None,
-            created_at_time: None,
-            memo: None,
-            amount: Nat::from(1_000_000_000_u128),
-        },
-    )
-    .unwrap();
-    withdraw(
-        env,
-        ledger_id,
-        user2,
-        WithdrawArgs {
-            from_subaccount: None,
-            to: depositor_id,
-            created_at_time: None,
-            amount: Nat::from(1_000_000_000_u128),
-        },
-    )
-    .unwrap();
+    env.deposit(user1, 2_000_000_000, None);
+    env.deposit(user2, 3_000_000_000, None);
+    let fee = env.icrc1_fee();
+    let _block_index = env
+        .icrc1_transfer(
+            user1.owner,
+            TransferArgs {
+                from_subaccount: None,
+                to: user2,
+                fee: None,
+                created_at_time: None,
+                memo: None,
+                amount: Nat::from(1_000_000_000_u128),
+            },
+        )
+        .unwrap();
+    let _withdraw_res = env
+        .withdraw(
+            user2,
+            WithdrawArgs {
+                from_subaccount: None,
+                to: env.depositor_id,
+                created_at_time: None,
+                amount: Nat::from(1_000_000_000_u128),
+            },
+        )
+        .unwrap();
 
     // total_supply should be 5m - 1m sent back to the depositor - twice the fee for transfer and withdraw
-    let expected_total_supply = 5_000_000_000 - 1_000_000_000 - 2 * fee.0.to_u128().unwrap();
-    assert_eq!(total_supply(env, ledger_id), expected_total_supply);
-    let upgrade_args = Encode!(&None::<LedgerArgs>).unwrap();
-    env.upgrade_canister(ledger_id, get_wasm("cycles-ledger"), upgrade_args, None)
-        .unwrap();
-    assert_eq!(total_supply(env, ledger_id), expected_total_supply);
-}
-
-// Validate that the given [response_certificate], [last_block_index], and [last_block_hash]
-// match the certified data from the ledger
-#[track_caller]
-fn validate_certificate(
-    env: &StateMachine,
-    ledger_id: Principal,
-    last_block_index: u64,
-    last_block_hash: Hash,
-) {
-    let DataCertificate {
-        certificate,
-        hash_tree,
-    } = get_tip_certificate(env, ledger_id);
-    let certificate = Certificate::from_cbor(certificate.as_slice()).unwrap();
-    assert_matches!(
-        certificate.verify(ledger_id.as_slice(), &env.root_key()),
-        Ok(_)
-    );
-
-    let certified_data_path: [&[u8]; 3] = [
-        "canister".as_bytes(),
-        ledger_id.as_slice(),
-        "certified_data".as_bytes(),
-    ];
-
-    let certified_data_hash = match certificate.tree.lookup_path(&certified_data_path) {
-        LookupResult::Found(v) => v,
-        _ => panic!("Unable to find the certificate_data_hash for the ledger canister in the hash_tree (hash_tree: {:?}, path: {:?})", certificate.tree, certified_data_path),
-    };
-
-    let hash_tree: HashTree = ciborium::de::from_reader(hash_tree.as_slice())
-        .expect("Unable to deserialize CBOR encoded hash_tree");
-
-    assert_eq!(certified_data_hash, hash_tree.digest());
-
-    let expected_last_block_hash = match hash_tree.lookup_subtree([b"last_block_hash"]) {
-        SubtreeLookupResult::Found(tree) => match tree.as_ref() {
-            HashTreeNode::Leaf(last_block_hash) => last_block_hash.clone(),
-            _ => panic!("last_block_hash value in the hash_tree should be a leaf"),
-        },
-        _ => panic!("last_block_hash not found in the response hash_tree"),
-    };
-    assert_eq!(last_block_hash.to_vec(), expected_last_block_hash);
-
-    let expected_last_block_index = match hash_tree.lookup_subtree([b"last_block_index"]) {
-        SubtreeLookupResult::Found(tree) => match tree.as_ref() {
-            HashTreeNode::Leaf(last_block_index_bytes) => {
-                u64::from_be_bytes(last_block_index_bytes.clone().try_into().unwrap())
-            }
-            _ => panic!("last_block_index value in the hash_tree should be a Leaf"),
-        },
-        _ => panic!("last_block_hash not found in the response hash_tree"),
-    };
-    assert_eq!(last_block_index, expected_last_block_index);
+    let expected_total_supply = 5_000_000_000 - 1_000_000_000 - 2 * fee;
+    assert_eq!(env.icrc1_total_supply(), expected_total_supply);
+    env.upgrade_ledger(None).unwrap();
+    assert_eq!(env.icrc1_total_supply(), expected_total_supply);
 }
 
 #[test]
 fn test_icrc3_get_blocks() {
     // Utility to extract all IDs and the corresponding blcks from the given [GetBlocksResult].
-    let get_txs = |res: &GetBlocksResult| -> Vec<(u64, Block)> {
-        res.blocks
-            .iter()
-            .map(|b| {
-                let block_id = b.id.0.to_u64().unwrap();
-                let block_decoded = Block::from_value(b.block.clone()).unwrap_or_else(|e| {
+    fn decode_blocks_with_ids(blocks: Vec<BlockWithId>) -> Vec<(u64, Block)> {
+        blocks
+            .into_iter()
+            .map(|BlockWithId { id, block }| {
+                let block_index = id.0.to_u64().unwrap();
+                let block_decoded = Block::from_value(block.clone()).unwrap_or_else(|e| {
                     panic!(
-                        "Unable to decode block at index:{} value:{:?} : {}",
-                        block_id, b.block, e
+                        "Unable to decode block at index:{block_index} value:{:?} : {e}",
+                        block
                     )
                 });
-                (block_id, block_decoded)
+                (block_index, block_decoded)
             })
             .collect()
-    };
+    }
 
-    let env = &new_state_machine();
-    let ledger_id = install_ledger(env);
+    let env = TestEnv::setup();
 
-    let txs = get_raw_blocks(env, ledger_id, vec![(0, 10)]);
-    assert_eq!(txs.log_length, 0_u128);
-    assert_eq!(txs.archived_blocks.len(), 0);
-    assert_eq!(get_txs(&txs), vec![]);
+    let get_blocks_res = env.icrc3_get_blocks(vec![(0u64, 10u64)]);
+    assert_eq!(get_blocks_res.log_length, 0_u128);
+    assert_eq!(get_blocks_res.archived_blocks.len(), 0);
+    assert_eq!(decode_blocks_with_ids(get_blocks_res.blocks), vec![]);
 
-    let depositor_id = install_depositor(env, ledger_id);
-    let user1 = Account::from(Principal::from_slice(&[1]));
-    let user2 = Account::from(Principal::from_slice(&[2]));
-    let user3 = Account::from(Principal::from_slice(&[3]));
+    let user1 = account(1, None);
+    let user2 = account(2, None);
+    let user3 = account(3, None);
 
     // add the first mint block
-    deposit(env, depositor_id, user1, 5_000_000_000, None);
+    env.deposit(user1, 5_000_000_000, None);
 
-    let txs = get_raw_blocks(env, ledger_id, vec![(0, 10)]);
-    assert_eq!(txs.log_length, 1_u128);
-    assert_eq!(txs.archived_blocks.len(), 0);
+    let get_blocks_res = env.icrc3_get_blocks(vec![(0u64, 10u64)]);
+    assert_eq!(get_blocks_res.log_length, 1_u128);
+    assert_eq!(get_blocks_res.archived_blocks.len(), 0);
     let mut block0 = block(
         Mint {
             to: user1,
@@ -1580,21 +1455,21 @@ fn test_icrc3_get_blocks() {
         None,
         None,
     );
-    let actual_txs = get_txs(&txs);
-    let expected_txs = vec![(0, block0.clone())];
-    assert_blocks_eq_except_ts(&actual_txs, &expected_txs);
+    let actual_blocks = decode_blocks_with_ids(get_blocks_res.blocks);
+    let expected_blocks = vec![(0, block0.clone())];
+    assert_blocks_eq_except_ts(&actual_blocks, &expected_blocks);
     // Replace the dummy timestamp in the crafted block with the real one,
     // i.e., the timestamp the ledger wrote in the real block. This is required
     // so that we can use the hash of the block as the parent hash.
-    block0.timestamp = actual_txs[0].1.timestamp;
-    validate_certificate(env, ledger_id, 0, block0.hash().unwrap());
+    block0.timestamp = actual_blocks[0].1.timestamp;
+    env.validate_certificate(0, block0.hash().unwrap());
 
     // add a second mint block
-    deposit(env, depositor_id, user2, 3_000_000_000, None);
+    env.deposit(user2, 3_000_000_000, None);
 
-    let txs = get_raw_blocks(env, ledger_id, vec![(0, 10)]);
-    assert_eq!(txs.log_length, 2_u128);
-    assert_eq!(txs.archived_blocks.len(), 0);
+    let get_blocks_res = env.icrc3_get_blocks(vec![(0u64, 10u64)]);
+    assert_eq!(get_blocks_res.log_length, 2_u128);
+    assert_eq!(get_blocks_res.archived_blocks.len(), 0);
     let mut block1 = block(
         Mint {
             to: user2,
@@ -1604,41 +1479,40 @@ fn test_icrc3_get_blocks() {
         None,
         Some(block0.hash().unwrap()),
     );
-    let actual_txs = get_txs(&txs);
-    let expected_txs = vec![(0, block0.clone()), (1, block1.clone())];
-    assert_blocks_eq_except_ts(&actual_txs, &expected_txs);
+    let actual_blocks = decode_blocks_with_ids(get_blocks_res.blocks);
+    let expected_blocks = vec![(0, block0.clone()), (1, block1.clone())];
+    assert_blocks_eq_except_ts(&actual_blocks, &expected_blocks);
     // Replace the dummy timestamp in the crafted block with the real one,
     // i.e., the timestamp the ledger wrote in the real block. This is required
     // so that we can use the hash of the block as the parent hash.
-    block1.timestamp = actual_txs[1].1.timestamp;
-    validate_certificate(env, ledger_id, 1, block1.hash().unwrap());
+    block1.timestamp = actual_blocks[1].1.timestamp;
+    env.validate_certificate(1, block1.hash().unwrap());
 
     // check retrieving a subset of the transactions
-    let txs = get_raw_blocks(env, ledger_id, vec![(0, 1)]);
-    assert_eq!(txs.log_length, 2_u128);
-    assert_eq!(txs.archived_blocks.len(), 0);
-    let actual_txs = get_txs(&txs);
-    let expected_txs = vec![(0, block0.clone())];
-    assert_blocks_eq_except_ts(&actual_txs, &expected_txs);
+    let get_blocks_res = env.icrc3_get_blocks(vec![(0u64, 1u64)]);
+    assert_eq!(get_blocks_res.log_length, 2_u128);
+    assert_eq!(get_blocks_res.archived_blocks.len(), 0);
+    let actual_blocks = decode_blocks_with_ids(get_blocks_res.blocks);
+    let expected_blocks = vec![(0, block0.clone())];
+    assert_blocks_eq_except_ts(&actual_blocks, &expected_blocks);
 
     // add a burn block
-    withdraw(
-        env,
-        ledger_id,
-        user2,
-        WithdrawArgs {
-            from_subaccount: None,
-            to: depositor_id,
-            created_at_time: None,
-            amount: Nat::from(2_000_000_000_u128),
-        },
-    )
-    .expect("Withdraw failed");
+    let _withdraw_res = env
+        .withdraw(
+            user2,
+            WithdrawArgs {
+                from_subaccount: None,
+                to: env.depositor_id,
+                created_at_time: None,
+                amount: Nat::from(2_000_000_000_u128),
+            },
+        )
+        .expect("Withdraw failed");
 
-    let txs = get_raw_blocks(env, ledger_id, vec![(0, 10)]);
-    assert_eq!(txs.log_length, 3_u128);
-    assert_eq!(txs.archived_blocks.len(), 0);
-    let withdraw_memo = encode_withdraw_memo(&depositor_id);
+    let get_blocks_res = env.icrc3_get_blocks(vec![(0u64, 10u64)]);
+    assert_eq!(get_blocks_res.log_length, 3_u128);
+    assert_eq!(get_blocks_res.archived_blocks.len(), 0);
+    let withdraw_memo = encode_withdraw_memo(&env.depositor_id);
     let mut block2 = block(
         Burn {
             from: user2,
@@ -1648,58 +1522,65 @@ fn test_icrc3_get_blocks() {
         Some(withdraw_memo),
         Some(block1.hash().unwrap()),
     );
-    let actual_txs = get_txs(&txs);
-    let expected_txs = vec![
+    let actual_blocks = decode_blocks_with_ids(get_blocks_res.blocks);
+    let expected_blocks = vec![
         (0, block0.clone()),
         (1, block1.clone()),
         (2, block2.clone()),
     ];
-    assert_blocks_eq_except_ts(&actual_txs, &expected_txs);
+    assert_blocks_eq_except_ts(&actual_blocks, &expected_blocks);
     // Replace the dummy timestamp in the crafted block with the real one,
     // i.e., the timestamp the ledger wrote in the real block. This is required
     // so that we can use the hash of the block as the parent hash.
-    block2.timestamp = actual_txs[2].1.timestamp;
-    validate_certificate(env, ledger_id, 2, block2.hash().unwrap());
+    block2.timestamp = actual_blocks[2].1.timestamp;
+    env.validate_certificate(2, block2.hash().unwrap());
 
     // add a couple of blocks
-    transfer(
-        env,
-        ledger_id,
-        user1.owner,
-        TransferArgs {
-            from_subaccount: None,
-            to: user2,
-            fee: None,
-            created_at_time: None,
+    let _block_index = env
+        .icrc1_transfer(
+            user1.owner,
+            TransferArgs {
+                from_subaccount: None,
+                to: user2,
+                fee: None,
+                created_at_time: None,
+                memo: None,
+                amount: Nat::from(1_000_000_000_u128),
+            },
+        )
+        .expect("Transfer failed");
+    let _block_index = env
+        .icrc2_approve(
+            user1.owner,
+            ApproveArgs {
+                from_subaccount: user1.subaccount,
+                spender: user2,
+                amount: Nat::from(1_000_000_000 + FEE),
+                expected_allowance: Some(Nat::from(0u64)),
+                expires_at: None,
+                fee: Some(Nat::from(FEE)),
+                memo: None,
+                created_at_time: None,
+            },
+        )
+        .expect("Approve failed");
+    let _block_index = env.icrc2_transfer_from_or_trap(
+        user2.owner,
+        TransferFromArgs {
+            spender_subaccount: user2.subaccount,
+            from: user1,
+            to: user3,
+            amount: Nat::from(1_000_000_000u64),
+            fee: Some(Nat::from(FEE)),
             memo: None,
-            amount: Nat::from(1_000_000_000_u128),
+            created_at_time: None,
         },
-    )
-    .expect("Transfer failed");
-    approve(
-        env,
-        ledger_id,
-        /*from:*/ user1,
-        /*spender:*/ user2,
-        /*amount:*/ 1_000_000_000 + FEE,
-        /*expected_allowance:*/ Some(0),
-        /*expires_at:*/ None,
-    )
-    .expect("Approve failed");
-    transfer_from(
-        env,
-        ledger_id,
-        /*from:*/ user1,
-        /*to:*/ user3,
-        /*spender:*/ user2,
-        /*amount:*/ 1_000_000_000,
-    )
-    .expect("Transfer from failed");
+    );
 
-    let txs = get_raw_blocks(env, ledger_id, vec![(0, 10)]);
-    assert_eq!(txs.log_length, 6_u128);
-    assert_eq!(txs.archived_blocks.len(), 0);
-    let actual_txs = get_txs(&txs);
+    let get_blocks_res = env.icrc3_get_blocks(vec![(0u64, 10u64)]);
+    assert_eq!(get_blocks_res.log_length, 6_u128);
+    assert_eq!(get_blocks_res.archived_blocks.len(), 0);
+    let actual_blocks = decode_blocks_with_ids(get_blocks_res.blocks);
     let block3 = block(
         Transfer {
             from: user1,
@@ -1723,7 +1604,7 @@ fn test_icrc3_get_blocks() {
         },
         None,
         None,
-        Some(actual_txs[3].1.hash().unwrap()),
+        Some(actual_blocks[3].1.hash().unwrap()),
     );
     let mut block5 = block(
         Transfer {
@@ -1735,9 +1616,9 @@ fn test_icrc3_get_blocks() {
         },
         None,
         None,
-        Some(actual_txs[4].1.hash().unwrap()),
+        Some(actual_blocks[4].1.hash().unwrap()),
     );
-    let expected_txs = vec![
+    let expected_blocks = vec![
         (0, block0.clone()),
         (1, block1.clone()),
         (2, block2.clone()),
@@ -1745,12 +1626,12 @@ fn test_icrc3_get_blocks() {
         (4, block4.clone()),
         (5, block5.clone()),
     ];
-    assert_blocks_eq_except_ts(&actual_txs, &expected_txs);
+    assert_blocks_eq_except_ts(&actual_blocks, &expected_blocks);
     // Replace the dummy timestamp in the crafted block with the real one,
     // i.e., the timestamp the ledger wrote in the real block. This is required
     // so that we can use the hash of the block as the parent hash.
-    block5.timestamp = actual_txs[5].1.timestamp;
-    validate_certificate(env, ledger_id, 5, block5.hash().unwrap());
+    block5.timestamp = actual_blocks[5].1.timestamp;
+    env.validate_certificate(5, block5.hash().unwrap());
 }
 
 // Checks two lists of blocks are the same.
@@ -1831,79 +1712,71 @@ fn test_get_blocks_max_length() {
     // per request to 2 instead of the default because
     // it's much faster to test.
 
-    let env = new_state_machine();
-    let max_blocks_per_request = 2;
-    let ledger_id = install_ledger_with_conf(
-        &env,
-        LedgerConfig {
-            max_blocks_per_request,
-            index_id: None,
-        },
-    );
-    let depositor_id = install_depositor(&env, ledger_id);
+    const MAX_BLOCKS_PER_REQUEST: u64 = 2;
+    let env = TestEnv::setup_with_ledger_conf(LedgerConfig {
+        max_blocks_per_request: MAX_BLOCKS_PER_REQUEST,
+        index_id: None,
+    });
 
-    let user = Account::from(Principal::from_slice(&[10]));
-    let _ = deposit(&env, depositor_id, user, 1_000_000_000, None);
-    let _ = deposit(&env, depositor_id, user, 2_000_000_000, None);
-    let _ = deposit(&env, depositor_id, user, 3_000_000_000, None);
-    let _ = deposit(&env, depositor_id, user, 4_000_000_000, None);
-    let _ = deposit(&env, depositor_id, user, 5_000_000_000, None);
+    let user = account(10, None);
+    let _deposit_res = env.deposit(user, 1_000_000_000, None);
+    let _deposit_res = env.deposit(user, 2_000_000_000, None);
+    let _deposit_res = env.deposit(user, 3_000_000_000, None);
+    let _deposit_res = env.deposit(user, 4_000_000_000, None);
+    let _deposit_res = env.deposit(user, 5_000_000_000, None);
 
-    let res = get_raw_blocks(&env, ledger_id, vec![(0, u64::MAX)]);
-    assert_eq!(max_blocks_per_request, res.blocks.len() as u64);
+    let res = env.icrc3_get_blocks(vec![(0, u64::MAX)]);
+    assert_eq!(MAX_BLOCKS_PER_REQUEST, res.blocks.len() as u64);
 
-    let res = get_raw_blocks(&env, ledger_id, vec![(3, u64::MAX)]);
-    assert_eq!(max_blocks_per_request, res.blocks.len() as u64);
+    let res = env.icrc3_get_blocks(vec![(3, u64::MAX)]);
+    assert_eq!(MAX_BLOCKS_PER_REQUEST, res.blocks.len() as u64);
 
-    let res = get_raw_blocks(&env, ledger_id, vec![(0, u64::MAX), (2, u64::MAX)]);
-    assert_eq!(max_blocks_per_request, res.blocks.len() as u64);
+    let res = env.icrc3_get_blocks(vec![(0, u64::MAX), (2, u64::MAX)]);
+    assert_eq!(MAX_BLOCKS_PER_REQUEST, res.blocks.len() as u64);
 }
 
 #[test]
 fn test_set_max_blocks_per_request_in_upgrade() {
-    let env = new_state_machine();
-    let ledger_id = install_ledger_with_conf(&env, LedgerConfig::default());
-    let depositor_id = install_depositor(&env, ledger_id);
+    let env = TestEnv::setup();
 
-    let user = Account::from(Principal::from_slice(&[10]));
-    let _ = deposit(&env, depositor_id, user, 1_000_000_000, None);
-    let _ = deposit(&env, depositor_id, user, 2_000_000_000, None);
-    let _ = deposit(&env, depositor_id, user, 3_000_000_000, None);
-    let _ = deposit(&env, depositor_id, user, 4_000_000_000, None);
-    let _ = deposit(&env, depositor_id, user, 5_000_000_000, None);
+    let user = account(10, None);
+    let _deposit_res = env.deposit(user, 1_000_000_000, None);
+    let _deposit_res = env.deposit(user, 2_000_000_000, None);
+    let _deposit_res = env.deposit(user, 3_000_000_000, None);
+    let _deposit_res = env.deposit(user, 4_000_000_000, None);
+    let _deposit_res = env.deposit(user, 5_000_000_000, None);
 
-    let res = get_raw_blocks(&env, ledger_id, vec![(0, u64::MAX)]);
+    let res = env.icrc3_get_blocks(vec![(0, u64::MAX)]);
     assert_eq!(5, res.blocks.len() as u64);
 
-    let max_blocks_per_request = 2;
+    const MAX_BLOCKS_PER_REQUEST: u64 = 2;
     let arg = Encode!(&Some(LedgerArgs::Upgrade(Some(UpgradeArgs {
-        max_blocks_per_request: Some(max_blocks_per_request),
+        max_blocks_per_request: Some(MAX_BLOCKS_PER_REQUEST),
         change_index_id: None,
     }))))
     .unwrap();
-    env.upgrade_canister(ledger_id, get_wasm("cycles-ledger"), arg, None)
+    env.state_machine
+        .upgrade_canister(env.ledger_id, get_wasm("cycles-ledger"), arg, None)
         .unwrap();
 
-    let res = get_raw_blocks(&env, ledger_id, vec![(0, u64::MAX)]);
-    assert_eq!(max_blocks_per_request, res.blocks.len() as u64);
+    let res = env.icrc3_get_blocks(vec![(0, u64::MAX)]);
+    assert_eq!(MAX_BLOCKS_PER_REQUEST, res.blocks.len() as u64);
 
-    let res = get_raw_blocks(&env, ledger_id, vec![(3, u64::MAX)]);
-    assert_eq!(max_blocks_per_request, res.blocks.len() as u64);
+    let res = env.icrc3_get_blocks(vec![(3, u64::MAX)]);
+    assert_eq!(MAX_BLOCKS_PER_REQUEST, res.blocks.len() as u64);
 
-    let res = get_raw_blocks(&env, ledger_id, vec![(0, u64::MAX), (2, u64::MAX)]);
-    assert_eq!(max_blocks_per_request, res.blocks.len() as u64);
+    let res = env.icrc3_get_blocks(vec![(0, u64::MAX), (2, u64::MAX)]);
+    assert_eq!(MAX_BLOCKS_PER_REQUEST, res.blocks.len() as u64);
 }
 
 #[test]
 fn test_set_index_id_in_init() {
-    let env = new_state_machine();
     let index_id = Principal::from_slice(&[111]);
-    let config = LedgerConfig {
+    let env = TestEnv::setup_with_ledger_conf(LedgerConfig {
         index_id: Some(index_id),
         ..Default::default()
-    };
-    let ledger_id = install_ledger_with_conf(&env, config);
-    let metadata = get_metadata(&env, ledger_id);
+    });
+    let metadata = env.icrc1_metadata();
     assert_eq!(
         metadata
             .iter()
@@ -1914,61 +1787,53 @@ fn test_set_index_id_in_init() {
 
 #[test]
 fn test_change_index_id() {
-    let env = new_state_machine();
-    let ledger_id = install_ledger_with_conf(&env, LedgerConfig::default());
-    let metadata = get_metadata(&env, ledger_id);
+    let env = TestEnv::setup();
 
     // by default there is no index_id set
+    let metadata = env.icrc1_metadata();
     assert!(metadata.iter().all(|(k, _)| k != "dfn:index_id"));
 
     // set the index_id
     let index_id = Principal::from_slice(&[111]);
-    let arg = Encode!(&Some(LedgerArgs::Upgrade(Some(UpgradeArgs {
+    let args = UpgradeArgs {
         max_blocks_per_request: None,
         change_index_id: Some(ChangeIndexId::SetTo(index_id)),
-    }))))
-    .unwrap();
-    env.upgrade_canister(ledger_id, get_wasm("cycles-ledger"), arg, None)
-        .unwrap();
-    let metadata = get_metadata(&env, ledger_id);
+    };
+    env.upgrade_ledger(Some(args)).unwrap();
     assert_eq!(
-        metadata
+        env.icrc1_metadata()
             .iter()
             .find_map(|(k, v)| if k == "dfn:index_id" { Some(v) } else { None }),
         Some(&index_id.as_slice().into()),
     );
 
     // unset the index_id
-    let arg = Encode!(&Some(LedgerArgs::Upgrade(Some(UpgradeArgs {
+    let args = UpgradeArgs {
         max_blocks_per_request: None,
         change_index_id: Some(ChangeIndexId::Unset),
-    }))))
-    .unwrap();
-    env.upgrade_canister(ledger_id, get_wasm("cycles-ledger"), arg, None)
-        .unwrap();
-    let metadata = get_metadata(&env, ledger_id);
+    };
+    env.upgrade_ledger(Some(args)).unwrap();
+    let metadata = env.icrc1_metadata();
     assert!(metadata.iter().all(|(k, _)| k != "dfn:index_id"));
 }
 
 #[tokio::test]
 async fn test_icrc1_test_suite() {
-    let env = new_state_machine();
-    let ledger_id = install_ledger(&env);
-    let depositor_id = install_depositor(&env, ledger_id);
-    let user = Account {
-        owner: Principal::from_slice(&[10]),
-        subaccount: Some([0; 32]),
-    };
+    let env = TestEnv::setup();
+    let user = account(10, None);
 
     // make the first deposit to the user and check the result
-    let deposit_res = deposit(&env, depositor_id, user, 1_000_000_000_000_000, None);
+    let deposit_res = env.deposit(user, 1_000_000_000_000_000, None);
     assert_eq!(deposit_res.block_index, Nat::from(0_u128));
     assert_eq!(deposit_res.balance, 1_000_000_000_000_000_u128);
-    assert_eq!(1_000_000_000_000_000, balance_of(&env, ledger_id, user));
+    assert_eq!(1_000_000_000_000_000, env.icrc1_balance_of(user));
 
     #[allow(clippy::arc_with_non_send_sync)]
-    let ledger_env =
-        icrc1_test_env_state_machine::SMLedger::new(Arc::new(env), ledger_id, user.owner);
+    let ledger_env = icrc1_test_env_state_machine::SMLedger::new(
+        Arc::new(env.state_machine),
+        env.ledger_id,
+        user.owner,
+    );
     let tests = icrc1_test_suite::test_suite(ledger_env).await;
     if !icrc1_test_suite::execute_tests(tests).await {
         panic!("The ICRC-1 test suite failed");
@@ -2018,7 +1883,8 @@ fn test_upgrade_preserves_state() {
         check_ledger_state(env, ledger_id, &expected_state);
     }
 
-    let expected_blocks = get_raw_blocks(env, ledger_id, vec![(0, u64::MAX)]);
+    let expected_blocks =
+        icrc3_get_blocks(env, ledger_id, vec![(Nat::from(0u64), Nat::from(u64::MAX))]);
 
     // upgrade the ledger
     let arg = Encode!(&None::<LedgerArgs>).unwrap();
@@ -2030,7 +1896,8 @@ fn test_upgrade_preserves_state() {
     check_ledger_state(env, ledger_id, &expected_state);
 
     // check that the blocks are all there after the upgrade
-    let after_upgrade_blocks = get_raw_blocks(env, ledger_id, vec![(0, u64::MAX)]);
+    let after_upgrade_blocks =
+        icrc3_get_blocks(env, ledger_id, vec![(Nat::from(0u64), Nat::from(u64::MAX))]);
     assert_eq!(expected_blocks, after_upgrade_blocks);
 }
 
@@ -2040,19 +1907,22 @@ fn check_ledger_state(
     ledger_id: Principal,
     expected_state: &CyclesLedgerInMemory,
 ) {
-    assert_eq!(expected_state.total_supply, total_supply(env, ledger_id));
+    assert_eq!(
+        expected_state.total_supply,
+        icrc1_total_supply(env, ledger_id)
+    );
 
     for (account, balance) in &expected_state.balances {
         assert_eq!(
             balance,
-            &balance_of(env, ledger_id, *account),
+            &icrc1_balance_of(env, ledger_id, *account),
             "balance_of({})",
             account
         );
     }
 
     for ((from, spender), allowance) in &expected_state.allowances {
-        let actual_allowance = get_allowance(env, ledger_id, *from, *spender).allowance;
+        let actual_allowance = icrc2_allowance(env, ledger_id, *from, *spender).allowance;
         assert_eq!(
             allowance,
             &actual_allowance.0.to_u128().unwrap(),
@@ -2080,7 +1950,7 @@ fn test_create_canister() {
     let deposit_res = deposit(&env, depositor_id, user, expected_balance, None);
     assert_eq!(deposit_res.block_index, Nat::from(0_u128));
     assert_eq!(deposit_res.balance, expected_balance);
-    assert_eq!(expected_balance, balance_of(&env, ledger_id, user));
+    assert_eq!(expected_balance, icrc1_balance_of(&env, ledger_id, user));
 
     // successful create
     let canister = create_canister(
@@ -2098,7 +1968,7 @@ fn test_create_canister() {
     .canister_id;
     expected_balance -= CREATE_CANISTER_CYCLES + FEE;
     let status = canister_status(&env, canister, user.owner);
-    assert_eq!(expected_balance, balance_of(&env, ledger_id, user));
+    assert_eq!(expected_balance, icrc1_balance_of(&env, ledger_id, user));
     // no canister creation fee on system subnet (where the StateMachine is by default)
     assert_eq!(CREATE_CANISTER_CYCLES, status.cycles);
     assert_eq!(vec![user.owner], status.settings.controllers);
@@ -2130,7 +2000,7 @@ fn test_create_canister() {
     .unwrap();
     expected_balance -= CREATE_CANISTER_CYCLES + FEE;
     let status = canister_status(&env, canister_id, user.owner);
-    assert_eq!(expected_balance, balance_of(&env, ledger_id, user));
+    assert_eq!(expected_balance, icrc1_balance_of(&env, ledger_id, user));
     assert_eq!(CREATE_CANISTER_CYCLES, status.cycles);
     // order is not guaranteed
     assert_eq!(
@@ -2186,7 +2056,7 @@ fn test_create_canister() {
     .unwrap();
     expected_balance -= CREATE_CANISTER_CYCLES + FEE;
     let status = canister_status(&env, canister_id, user.owner);
-    assert_eq!(expected_balance, balance_of(&env, ledger_id, user));
+    assert_eq!(expected_balance, icrc1_balance_of(&env, ledger_id, user));
     assert_eq!(CREATE_CANISTER_CYCLES, status.cycles);
     assert_eq!(status.settings.controllers, vec![user.owner]);
 
@@ -2253,7 +2123,7 @@ fn test_create_canister() {
                 ..
             }
         );
-        assert_eq!(expected_balance, balance_of(&env, ledger_id, user));
+        assert_eq!(expected_balance, icrc1_balance_of(&env, ledger_id, user));
     } else {
         panic!("wrong error")
     };
@@ -2303,7 +2173,7 @@ fn test_create_canister() {
                 ..
             }
         );
-        assert_eq!(expected_balance, balance_of(&env, ledger_id, user));
+        assert_eq!(expected_balance, icrc1_balance_of(&env, ledger_id, user));
     } else {
         panic!("wrong error")
     };
@@ -2344,7 +2214,7 @@ fn test_create_canister() {
             }
         );
         assert!(refund_block.is_none());
-        assert_eq!(expected_balance, balance_of(&env, ledger_id, user));
+        assert_eq!(expected_balance, icrc1_balance_of(&env, ledger_id, user));
     } else {
         panic!("wrong error")
     };
@@ -2361,7 +2231,7 @@ fn test_create_canister() {
         .canister_id;
     expected_balance -= CREATE_CANISTER_CYCLES + FEE;
     let status = canister_status(&env, canister, user.owner);
-    assert_eq!(expected_balance, balance_of(&env, ledger_id, user));
+    assert_eq!(expected_balance, icrc1_balance_of(&env, ledger_id, user));
     assert_eq!(CREATE_CANISTER_CYCLES, status.cycles);
     assert_eq!(vec![user.owner], status.settings.controllers);
     let duplicate = create_canister(&env, ledger_id, user, arg).unwrap_err();
@@ -2403,7 +2273,7 @@ fn test_create_canister_duplicate() {
     let deposit_res = deposit(&env, depositor_id, user, expected_balance, None);
     assert_eq!(deposit_res.block_index, Nat::from(0u128));
     assert_eq!(deposit_res.balance, expected_balance);
-    assert_eq!(expected_balance, balance_of(&env, ledger_id, user));
+    assert_eq!(expected_balance, icrc1_balance_of(&env, ledger_id, user));
 
     let now = env
         .time()
@@ -2426,7 +2296,7 @@ fn test_create_canister_duplicate() {
     .canister_id;
     expected_balance -= CREATE_CANISTER_CYCLES + FEE;
     let status = canister_status(&env, canister, user.owner);
-    assert_eq!(expected_balance, balance_of(&env, ledger_id, user));
+    assert_eq!(expected_balance, icrc1_balance_of(&env, ledger_id, user));
     // no canister creation fee on system subnet (where the StateMachine is by default)
     assert_eq!(CREATE_CANISTER_CYCLES, status.cycles);
     assert_eq!(vec![user.owner], status.settings.controllers);
@@ -2454,61 +2324,33 @@ fn test_create_canister_duplicate() {
 #[test]
 #[should_panic(expected = "memo length exceeds the maximum")]
 fn test_deposit_invalid_memo() {
-    let env = &new_state_machine();
-    let ledger_id = install_ledger(env);
-    let depositor_id = install_depositor(env, ledger_id);
-    let user = Account {
-        owner: Principal::from_slice(&[1]),
-        subaccount: None,
-    };
+    let env = TestEnv::setup();
 
     // Attempt deposit with memo exceeding `MAX_MEMO_LENGTH`. This call should panic.
-    let large_memo = [0; MAX_MEMO_LENGTH as usize + 1];
-
-    let arg = Encode!(&depositor::endpoints::DepositArg {
-        cycles: 10 * FEE,
-        to: user,
-        memo: Some(Memo(ByteBuf::from(large_memo))),
-    })
-    .unwrap();
-
-    let _res = env
-        .update_call(depositor_id, user.owner, "deposit", arg)
-        .unwrap();
+    let _res = env.deposit(
+        account(1, None),
+        10 * FEE,
+        Some(Memo(ByteBuf::from([0; MAX_MEMO_LENGTH as usize + 1]))),
+    );
 }
 
 #[test]
 #[should_panic(expected = "memo length exceeds the maximum")]
 fn test_icrc1_transfer_invalid_memo() {
-    let env = &new_state_machine();
-    let ledger_id = install_ledger(env);
-    let depositor_id = install_depositor(env, ledger_id);
-    let user1 = Account {
-        owner: Principal::from_slice(&[1]),
-        subaccount: None,
-    };
-    let user2: Account = Account {
-        owner: Principal::from_slice(&[2]),
-        subaccount: None,
-    };
-    let deposit_amount = 1_000_000_000;
-    deposit(env, depositor_id, user1, deposit_amount, None);
+    let env = TestEnv::setup();
+    let user1 = account(1, None);
+    let _deposit_res = env.deposit(user1, 1_000_000_000, None);
 
     // Attempt icrc1_transfer with memo exceeding `MAX_MEMO_LENGTH`. This call should panic.
-    let large_memo = [0; MAX_MEMO_LENGTH as usize + 1];
-
-    let transfer_amount = Nat::from(100_000_u128);
-    let _res = transfer(
-        env,
-        ledger_id,
+    let _res = env.icrc1_transfer(
         user1.owner,
         TransferArgs {
             from_subaccount: None,
-            to: user2,
+            to: account(2, None),
             fee: None,
             created_at_time: None,
-            memo: Some(Memo(ByteBuf::from(large_memo))),
-            amount: transfer_amount.clone(),
+            memo: Some(Memo(ByteBuf::from([0; MAX_MEMO_LENGTH as usize + 1]))),
+            amount: Nat::from(100_000_u128),
         },
     );
 }
@@ -2516,106 +2358,62 @@ fn test_icrc1_transfer_invalid_memo() {
 #[test]
 #[should_panic(expected = "memo length exceeds the maximum")]
 fn test_approve_invalid_memo() {
-    let env = &new_state_machine();
-    let ledger_id = install_ledger(env);
-    let depositor_id = install_depositor(env, ledger_id);
-    let user1 = Account {
-        owner: Principal::from_slice(&[1]),
-        subaccount: None,
-    };
-    let user2: Account = Account {
-        owner: Principal::from_slice(&[2]),
-        subaccount: None,
-    };
-    let deposit_amount = 1_000_000_000;
-    deposit(env, depositor_id, user1, deposit_amount, None);
+    let env = TestEnv::setup();
+    let user1 = account(1, None);
+    let _deposit_res = env.deposit(user1, 1_000_000_000, None);
 
     // Attempt approve with memo exceeding `MAX_MEMO_LENGTH`. This call should panic.
-    let large_memo = [0; MAX_MEMO_LENGTH as usize + 1];
-
-    let args = ApproveArgs {
-        from_subaccount: None,
-        spender: user2,
-        amount: (1_000_000_000 + FEE).into(),
-        expected_allowance: Some(Nat::from(0u128)),
-        expires_at: None,
-        fee: Some(Nat::from(FEE)),
-        memo: Some(Memo(ByteBuf::from(large_memo))),
-        created_at_time: None,
-    };
-    let res = if let WasmResult::Reply(res) = env
-        .update_call(
-            ledger_id,
-            user1.owner,
-            "icrc2_approve",
-            Encode!(&args).unwrap(),
-        )
-        .unwrap()
-    {
-        Decode!(&res, Result<Nat, ApproveError>).unwrap()
-    } else {
-        panic!("icrc2_approve rejected")
-    };
-
-    res.unwrap();
+    let _approve_res = env.icrc2_approve(
+        user1.owner,
+        ApproveArgs {
+            from_subaccount: None,
+            spender: account(2, None),
+            amount: (1_000_000_000 + FEE).into(),
+            expected_allowance: Some(Nat::from(0u128)),
+            expires_at: None,
+            fee: Some(Nat::from(FEE)),
+            memo: Some(Memo(ByteBuf::from([0; MAX_MEMO_LENGTH as usize + 1]))),
+            created_at_time: None,
+        },
+    );
 }
 
 #[test]
 #[should_panic(expected = "memo length exceeds the maximum")]
 fn test_icrc2_transfer_from_invalid_memo() {
-    let env = &new_state_machine();
-    let ledger_id = install_ledger(env);
-    let depositor_id = install_depositor(env, ledger_id);
-    let user1 = Account {
-        owner: Principal::from_slice(&[1]),
-        subaccount: None,
-    };
-    let user2: Account = Account {
-        owner: Principal::from_slice(&[2]),
-        subaccount: None,
-    };
+    let env = TestEnv::setup();
+    let user1 = account(1, None);
+    let user2 = account(2, None);
     let deposit_amount = 10_000_000_000;
-    deposit(env, depositor_id, user1, deposit_amount, None);
+    let _deposit_res = env.deposit(user1, deposit_amount, None);
+
+    let _block_index = env
+        .icrc2_approve(
+            user1.owner,
+            ApproveArgs {
+                from_subaccount: user1.subaccount,
+                spender: user2,
+                amount: Nat::from(1_000_000_000 + FEE),
+                expected_allowance: Some(Nat::from(0u64)),
+                expires_at: None,
+                fee: None,
+                memo: None,
+                created_at_time: None,
+            },
+        )
+        .expect("Approve failed");
 
     // Attempt transfer_from with memo exceeding `MAX_MEMO_LENGTH`. This call should panic.
-    let large_memo = [0; MAX_MEMO_LENGTH as usize + 1];
-
-    let transfer_amount = Nat::from(100_000_u128);
-
-    approve(
-        env,
-        ledger_id,
-        /*from:*/ user1,
-        /*spender:*/ user2,
-        /*amount:*/ 1_000_000_000 + FEE,
-        /*expected_allowance:*/ Some(0),
-        /*expires_at:*/ None,
-    )
-    .expect("Approve failed");
-
-    let args = TransferFromArgs {
-        spender_subaccount: None,
-        from: user1,
-        to: user2,
-        amount: transfer_amount,
-        fee: Some(Nat::from(FEE)),
-        memo: Some(Memo(ByteBuf::from(large_memo))),
-        created_at_time: None,
-    };
-
-    let res = if let WasmResult::Reply(res) = env
-        .update_call(
-            ledger_id,
-            user2.owner,
-            "icrc2_transfer_from",
-            Encode!(&args).unwrap(),
-        )
-        .unwrap()
-    {
-        Decode!(&res, Result<Nat, TransferFromError>).unwrap()
-    } else {
-        panic!("icrc2_transfer_from rejected")
-    };
-
-    res.unwrap();
+    let _transfer_from_res = env.icrc2_transfer_from(
+        user2.owner,
+        TransferFromArgs {
+            spender_subaccount: None,
+            from: user1,
+            to: user2,
+            amount: Nat::from(100_000_u128),
+            fee: Some(Nat::from(FEE)),
+            memo: Some(Memo(ByteBuf::from([0; MAX_MEMO_LENGTH as usize + 1]))),
+            created_at_time: None,
+        },
+    );
 }

--- a/cycles-ledger/tests/tests.rs
+++ b/cycles-ledger/tests/tests.rs
@@ -990,7 +990,7 @@ fn test_approval_expiring() {
         )
         .expect("approve failed");
     assert_eq!(block_index, 1_u128);
-    // TODO: check the block
+    // TODO(FI-1205): check the block
     let allowance = env.icrc2_allowance(from, spender1);
     assert_eq!(allowance.allowance, Nat::from(100_000_000_u128));
     assert_eq!(allowance.expires_at, Some(expiration));
@@ -1014,7 +1014,7 @@ fn test_approval_expiring() {
         )
         .expect("approve failed");
     assert_eq!(block_index, 2_u128);
-    // TODO: check the block
+    // TODO(FI-1205): check the block
     let allowance = env.icrc2_allowance(from, spender2);
     assert_eq!(allowance.allowance, Nat::from(200_000_000_u128));
     assert_eq!(allowance.expires_at, Some(expiration_3h));
@@ -1038,7 +1038,7 @@ fn test_approval_expiring() {
             created_at_time: None,
         },
     );
-    // TODO: check the block
+    // TODO(FI-1205): check the block
     let allowance = env.icrc2_allowance(from, spender3);
     assert_eq!(allowance.allowance, Nat::from(300_000_000_u128));
     assert_eq!(allowance.expires_at, Some(expiration_3h));
@@ -1065,7 +1065,7 @@ fn test_approval_expiring() {
                 created_at_time: None,
             },
         )
-        .unwrap_err(); // TODO: check the error
+        .unwrap_err(); // TODO(FI-1206): check the error
         env.icrc2_approve(
             owner,
             ApproveArgs {
@@ -1079,7 +1079,7 @@ fn test_approval_expiring() {
                 created_at_time: None,
             },
         )
-        .unwrap_err(); // TODO: check the error
+        .unwrap_err(); // TODO(FI-1206): check the error
     }
 }
 


### PR DESCRIPTION
1. remove useless parts of the tests.
2. proper naming for client functions, e.g. `icrc3_get_blocks` instead `get_raw_blocks`. In general, each function has been changed to use the name of the canister method that it is calling.
3. Add `TestEnv` to replace test setup (created `StateMachine`->install ledger->install depositor) with a single function and to avoid passing `env` and the canister id to every client function. E.g. `icrc1_total_supply(env, ledger_id)` is now `env.icrc1_total_supply()`.
5. Standardize how arguments are passed to functions. Most functions now take in input the `Principal` caller and a single argument which is the payload to serialize and pass in the call. Note that for egonomics reasons some functions, such as `deposit` and `icrc3_get_blocks`, take in input a different set of arguments that is easier to use in the tests.
6. Avoid hardcoded arguments so that tests can actually test all permutations.
7. Standardize the errors given by function calles. No more `.unwrap()` which wouldn't really tell you want the error is. Now each funciton will print out the call input and the resulting error.
8. Replace `CyclesLedgerInStateMachine` with `TestEnv` to unify the `client` and `gen` mod. The Ledger installed in a `StateMachine` is now always represented by `TestEnv`.