### PR TITLE
feat: reimburse fee

### DIFF
--- a/cycles-ledger/tests/client.rs
+++ b/cycles-ledger/tests/client.rs
@@ -140,10 +140,10 @@ pub fn withdraw(
 pub fn create_canister(
     env: &StateMachine,
     ledger_id: Principal,
-    from: Account,
+    caller: Principal,
     args: CreateCanisterArgs,
 ) -> Result<CreateCanisterSuccess, endpoints::CreateCanisterError> {
-    update_or_panic(env, ledger_id, from.owner, "create_canister", args)
+    update_or_panic(env, ledger_id, caller, "create_canister", args)
 }
 
 pub fn canister_status(

--- a/cycles-ledger/tests/tests.rs
+++ b/cycles-ledger/tests/tests.rs
@@ -2238,6 +2238,7 @@ fn check_ledger_state(env: &TestEnv, expected_state: &CyclesLedgerInMemory) {
 #[test]
 fn test_create_canister() {
     const CREATE_CANISTER_CYCLES: u128 = 1_000_000_000_000;
+    const CREATE_CANISTER_CYCLES_MINUS_FEE: u128 = 1_000_000_000_000 - FEE;
     let env = new_state_machine();
     install_fake_cmc(&env);
     let ledger_id = install_ledger(&env);
@@ -2418,7 +2419,7 @@ fn test_create_canister() {
     )
     .unwrap_err()
     {
-        expected_balance -= FEE;
+        expected_balance -= 2 * FEE;
         assert_matches!(
             get_block(&env, ledger_id, fee_block.unwrap())
                 .transaction
@@ -2433,7 +2434,7 @@ fn test_create_canister() {
                 .transaction
                 .operation,
             Operation::Mint {
-                amount: CREATE_CANISTER_CYCLES,
+                amount: CREATE_CANISTER_CYCLES_MINUS_FEE,
                 ..
             }
         );
@@ -2447,6 +2448,7 @@ fn test_create_canister() {
 
     // dividing by 3 so that the number of cyles to be refunded is different from the amount of cycles consumed
     const REFUND_AMOUNT: u128 = CREATE_CANISTER_CYCLES / 3;
+    const REFUND_AMOUNT_MINUS_FEE: u128 = REFUND_AMOUNT - FEE;
     fail_next_create_canister_with(
         &env,
         cycles_ledger::endpoints::CmcCreateCanisterError::Refunded {
@@ -2471,7 +2473,7 @@ fn test_create_canister() {
     )
     .unwrap_err()
     {
-        expected_balance -= FEE + (CREATE_CANISTER_CYCLES - REFUND_AMOUNT);
+        expected_balance -= 2 * FEE + (CREATE_CANISTER_CYCLES - REFUND_AMOUNT);
         assert_matches!(
             get_block(&env, ledger_id, fee_block.unwrap())
                 .transaction
@@ -2486,7 +2488,7 @@ fn test_create_canister() {
                 .transaction
                 .operation,
             Operation::Mint {
-                amount: REFUND_AMOUNT,
+                amount: REFUND_AMOUNT_MINUS_FEE,
                 ..
             }
         );

--- a/cycles-ledger/tests/tests.rs
+++ b/cycles-ledger/tests/tests.rs
@@ -1025,6 +1025,7 @@ fn test_withdraw_fails() {
     // user keeps the cycles if they don't have enough balance to pay the fee
     let account2 = account(2, None);
     let _deposit_res = env.deposit(account2, FEE + 1, None);
+    let blocks = env.get_all_blocks_with_ids();
     let _withdraw_res = env
         .withdraw(
             account2.owner,
@@ -1062,6 +1063,7 @@ fn test_withdraw_fails() {
         amount: Nat::from(FEE),
     };
     let duplicate_of = env.withdraw_or_trap(account2.owner, args.clone());
+    let blocks = env.get_all_blocks_with_ids();
     // the same withdraw should fail because created_at_time is set and the args are the same
     assert_eq!(
         env.withdraw(account2.owner, args),

--- a/cycles-ledger/tests/tests.rs
+++ b/cycles-ledger/tests/tests.rs
@@ -934,8 +934,13 @@ fn test_withdraw_fails() {
             ..
         }
     ));
-    assert_eq!(balance_before_attempt - FEE, env.icrc1_balance_of(account1));
-    expected_total_supply -= FEE;
+    // the caller pays the fee twice: once for the burn block and
+    // once for the refund block
+    assert_eq!(
+        balance_before_attempt - 2 * FEE,
+        env.icrc1_balance_of(account1)
+    );
+    expected_total_supply -= 2 * FEE;
     assert_eq!(env.icrc1_total_supply(), expected_total_supply,);
     // the destination invalid error happens after the burn block
     // was created and balances were changed. In other to fix the
@@ -972,7 +977,9 @@ fn test_withdraw_fails() {
                 memo: Some(Memo(ByteBuf::from(PENALIZE_MEMO))),
                 operation: Operation::Mint {
                     to: account1,
-                    amount: 500_000_000_u128,
+                    // refund the amount minus the fee to make
+                    // the caller pay for the refund block too
+                    amount: 500_000_000_u128 - FEE,
                 },
             },
         }

--- a/cycles-ledger/tests/tests.rs
+++ b/cycles-ledger/tests/tests.rs
@@ -2723,7 +2723,7 @@ fn test_create_canister_fail() {
         .unwrap(),
     };
     let blocks = blocks.into_iter().chain([burn_block]).collect::<Vec<_>>();
-    assert_vec_display_eq(&blocks, &env.get_all_blocks_with_ids());
+    assert_vec_display_eq(&blocks, env.get_all_blocks_with_ids());
 
     // if refund_amount is > env.icrc1_fee() then
     // 1. the error has the refund_block

--- a/cycles-ledger/tests/tests.rs
+++ b/cycles-ledger/tests/tests.rs
@@ -1020,7 +1020,7 @@ fn test_withdraw_fails() {
         .into_iter()
         .chain([burn_block, refund_block])
         .collect::<Vec<_>>();
-    assert_vec_display_eq(&blocks, env.get_all_blocks_with_ids());
+    assert_vec_display_eq(blocks, env.get_all_blocks_with_ids());
 
     // user keeps the cycles if they don't have enough balance to pay the fee
     let account2 = account(2, None);
@@ -1051,7 +1051,7 @@ fn test_withdraw_fails() {
         .unwrap_err();
     assert_eq!(FEE + 1, env.icrc1_balance_of(account2));
     // check that no new blocks was added.
-    assert_vec_display_eq(&blocks, env.get_all_blocks_with_ids());
+    assert_vec_display_eq(blocks, env.get_all_blocks_with_ids());
 
     // test withdraw deduplication
     let _deposit_res = env.deposit(account2, FEE * 3, None);
@@ -1070,7 +1070,7 @@ fn test_withdraw_fails() {
         Err(WithdrawError::Duplicate { duplicate_of })
     );
     // check that no new blocks was added.
-    assert_vec_display_eq(&blocks, env.get_all_blocks_with_ids());
+    assert_vec_display_eq(blocks, env.get_all_blocks_with_ids());
 }
 
 #[test]


### PR DESCRIPTION
1. change `withdraw` and `create_canister` such that the user pays a fee in case of reimburse/penalized block is created
2. fix a bug in `assert_vec_display_eq`