### PR TITLE
chore: bump ic-cdk patch version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ## [Unreleased] - ReleaseDate
 
+* Update `ic-cdk` dependency to patch a memory leak.
+
 ## [1.0.0] - 2024-06-18
 * Added the logo to the metadata value `icrc1:logo`.
 * Fixed a bug where the cycles ledger took control over a newly created canister if `creation_args` is `Some` and `canister_settings` is `None`.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -733,9 +733,9 @@ dependencies = [
 
 [[package]]
 name = "ic-cdk"
-version = "0.12.1"
+version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f3d204af0b11c45715169c997858edb58fa8407d08f4fae78a6b415dd39a362"
+checksum = "0e908da565d9e304e83732500069ebb959e3d2cad80f894889ea37207112c7a0"
 dependencies = [
  "candid",
  "ic-cdk-macros",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ publish = false                                         # don't publish to crate
 [workspace.dependencies]
 candid = "0.10"
 candid_parser = "0.1"
-ic-cdk = { version = "0.12.1" }
+ic-cdk = { version = "0.12.2" }
 ic-cdk-macros = { version = "0.8.4" }
 icrc-ledger-types = "0.1.5"
 serde = "1"


### PR DESCRIPTION
Bump `ic-cdk` to the latest patch version to fix a memory leak