### PR TITLE
fix: FI-1574: last_block_index shall be leb128 encoded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 # CHANGELOG
 
 ## [Unreleased] - ReleaseDate
+* Adapted `icrc3_get_tip_certificate` to be compliant with the ICRC-3 specification by changing the encoding of `last_block_index` to `leb128`.
 
 ## [1.0.2] - 2024-10-28
 * Added `get_icp_xdr_conversion_rate` to mock CMC

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -386,6 +386,7 @@ dependencies = [
  "icrc1-test-env-state-machine",
  "icrc1-test-suite",
  "lazy_static",
+ "leb128",
  "minicbor",
  "num-bigint",
  "num-traits",

--- a/cycles-ledger/Cargo.toml
+++ b/cycles-ledger/Cargo.toml
@@ -28,6 +28,7 @@ ic-canister-log = "0.2.0"
 ic-canisters-http-types = { git = "https://github.com/dfinity/ic", rev = "b2f18ac0794d2225b53d9c3190b60dbadb4ac9b9" }
 ic-metrics-encoder = "1.1"
 serde_json = "1.0.107"
+leb128 = "0.2.5"
 
 [dev-dependencies]
 assert_matches = "1.5.0"

--- a/cycles-ledger/src/storage.rs
+++ b/cycles-ledger/src/storage.rs
@@ -2721,7 +2721,7 @@ mod tests {
 
     #[test]
     fn test_u64_to_leb128() {
-        for i in [0, 1, u64::MAX-1, u64::MAX] {
+        for i in [0, 1, u64::MAX - 1, u64::MAX] {
             let mut buf = Vec::with_capacity(crate::storage::MAX_U64_ENCODING_BYTES);
             leb128::write::unsigned(&mut buf, i).unwrap();
             let decoded = leb128::read::unsigned(&mut buf.as_slice()).unwrap();

--- a/cycles-ledger/src/storage.rs
+++ b/cycles-ledger/src/storage.rs
@@ -2718,6 +2718,16 @@ mod tests {
             },
         }
     }
+
+    #[test]
+    fn test_u64_to_leb128() {
+        for i in [0, 1, u64::MAX-1, u64::MAX] {
+            let mut buf = Vec::with_capacity(crate::storage::MAX_U64_ENCODING_BYTES);
+            leb128::write::unsigned(&mut buf, i).unwrap();
+            let decoded = leb128::read::unsigned(&mut buf.as_slice()).unwrap();
+            assert_eq!(i, decoded);
+        }
+    }
 }
 
 mod phash {

--- a/cycles-ledger/src/storage.rs
+++ b/cycles-ledger/src/storage.rs
@@ -775,7 +775,7 @@ fn check_invariants(s: &State) {
     }
 }
 
-/// The maximum amount of bytes a 64-bit number can occupy when encoded in LEB128.
+/// The maximum number of bytes a 64-bit number can occupy when encoded in LEB128.
 const MAX_U64_ENCODING_BYTES: usize = 10;
 
 pub fn populate_last_block_hash_and_hash_tree(

--- a/cycles-ledger/src/storage.rs
+++ b/cycles-ledger/src/storage.rs
@@ -775,12 +775,17 @@ fn check_invariants(s: &State) {
     }
 }
 
+/// The maximum amount of bytes a 64-bit number can occupy when encoded in LEB128.
+const MAX_U64_ENCODING_BYTES: usize = 10;
+
 pub fn populate_last_block_hash_and_hash_tree(
     hash_tree: &mut RbTree<&'static str, Vec<u8>>,
     last_block_index: u64,
     last_block_hash: Hash,
 ) {
-    hash_tree.insert("last_block_index", last_block_index.to_be_bytes().to_vec());
+    let mut last_block_index_buf = Vec::with_capacity(MAX_U64_ENCODING_BYTES);
+    leb128::write::unsigned(&mut last_block_index_buf, last_block_index).unwrap();
+    hash_tree.insert("last_block_index", last_block_index_buf.to_vec());
     hash_tree.insert("last_block_hash", last_block_hash.to_vec());
 }
 

--- a/cycles-ledger/tests/tests.rs
+++ b/cycles-ledger/tests/tests.rs
@@ -563,7 +563,8 @@ impl TestEnv {
         let expected_last_block_index = match hash_tree.lookup_subtree([b"last_block_index"]) {
             SubtreeLookupResult::Found(tree) => match tree.as_ref() {
                 HashTreeNode::Leaf(last_block_index_bytes) => {
-                    u64::from_be_bytes(last_block_index_bytes.clone().try_into().unwrap())
+                    leb128::read::unsigned(&mut last_block_index_bytes.as_slice())
+                        .expect("Unable to read last_block_index from the hash_tree")
                 }
                 _ => panic!("last_block_index value in the hash_tree should be a Leaf"),
             },


### PR DESCRIPTION
The [ICRC-3 standard](https://github.com/dfinity/ICRC-1/tree/main/standards/ICRC-3#blocks-verification) specifies that the `last_block_index` value in the certificate returned from the `icrc3_get_tip_certificate` endpoint shall be encoded using [leb128](https://en.wikipedia.org/wiki/LEB128#Unsigned_LEB128). The value has until now been encoded as a Big Endian-encoded `u64`, but this PR proposes to change that to a `leb128` encoding as per the ICRC-3 standard.