### PR TITLE
fix: blocks can have decreasing timestamps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
           sudo apt install -y protobuf-compiler libprotobuf-dev
 
       - name: Cache Cargo
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: |
             ~/.cargo/registry
@@ -33,7 +33,7 @@ jobs:
           rustup show
 
       - name: Cache StateMachine
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ic-test-state-machine
           key: ${{ matrix.ic-commit }}-statemachine-binary

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ## [Unreleased] - ReleaseDate
 
+* Fixed a bug where refund blocks after an unsuccessful `withdraw` or `create_canister` had the timestamp of the initial burn block instead of the time when the error was processed. Approvals that have expired in the meantime will not be refunded.
+
 ## [1.0.3] - 2024-11-18
 * Adapted `icrc3_get_tip_certificate` to be compliant with the ICRC-3 specification by changing the encoding of `last_block_index` to `leb128`.
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@
 FROM --platform=linux/amd64 ubuntu:20.04 as builder
 SHELL ["bash", "-c"]
 
-ARG rust_version=1.72.0
+ARG rust_version=1.85.0
 
 ENV TZ=UTC
 
@@ -30,7 +30,8 @@ ENV RUSTUP_HOME=/opt/rustup \
 RUN curl --fail https://sh.rustup.rs -sSf \
     | sh -s -- -y --default-toolchain ${rust_version}-x86_64-unknown-linux-gnu --no-modify-path && \
     rustup default ${rust_version}-x86_64-unknown-linux-gnu && \
-    rustup target add wasm32-unknown-unknown
+    rustup target add wasm32-unknown-unknown && \
+    rustup show active-toolchain || rustup toolchain install
 
 ENV PATH=/cargo/bin:$PATH
 

--- a/cycles-ledger/src/lib.rs
+++ b/cycles-ledger/src/lib.rs
@@ -132,7 +132,7 @@ pub fn generic_to_ciborium_value(value: &Value, depth: usize) -> anyhow::Result<
         )),
         Value::Nat(nat) => {
             let value_bytes = nat.0.to_bytes_be();
-            let value = CiboriumValue::try_from(value_bytes)?;
+            let value = CiboriumValue::from(value_bytes);
             Ok(CiboriumValue::Tag(known_tags::BIGNUM, Box::new(value)))
         }
         v => bail!("Unknown value: {:?}", v),

--- a/cycles-ledger/src/storage.rs
+++ b/cycles-ledger/src/storage.rs
@@ -1811,6 +1811,7 @@ pub async fn withdraw(
 
     // 2. call deposit_cycles on the management canister
     let deposit_cycles_result = deposit_cycles(CanisterIdRecord { canister_id: to }, amount).await;
+    let now = ic_cdk::api::time();
 
     // 3. if 2. fails then mint cycles
     if let Err((rejection_code, rejection_reason)) = deposit_cycles_result {
@@ -1825,7 +1826,6 @@ pub async fn withdraw(
                 rejection_reason,
             });
         }
-        let now = ic_cdk::api::time();
         match reimburse(from, amount_to_reimburse, now, PENALIZE_MEMO) {
             Ok(fee_block) => {
                 prune(now);
@@ -1992,6 +1992,7 @@ pub async fn create_canister(
         (Result<Principal, CmcCreateCanisterError>,),
         (RejectionCode, String),
     > = call_with_payment128(CMC_PRINCIPAL, "create_canister", (argument,), amount).await;
+    let now = ic_cdk::api::time();
 
     // 3. if 2. fails then mint cycles
 
@@ -2029,7 +2030,6 @@ pub async fn create_canister(
                     rejection_reason,
                 });
             }
-            let now = ic_cdk::api::time();
             match reimburse(from, amount_to_reimburse, now, REFUND_MEMO) {
                 Ok(refund_block) => {
                     prune(now);

--- a/cycles-ledger/src/storage.rs
+++ b/cycles-ledger/src/storage.rs
@@ -1537,7 +1537,7 @@ fn check_duplicate(transaction: &Transaction) -> Result<(), ProcessTransactionEr
     {
         return Err(PTErr::Duplicate {
             duplicate_of: block_index,
-            canister_id: maybe_canister.map(Into::into),
+            canister_id: maybe_canister,
         });
     }
 

--- a/dfx.json
+++ b/dfx.json
@@ -1,5 +1,5 @@
 {
-  "dfx": "0.18.0",
+  "dfx": "0.25.0",
   "canisters": {
     "cycles-ledger": {
       "type": "rust",

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.72.0"
+channel = "1.85.0"
 targets = ["wasm32-unknown-unknown"]
 components = ["rustfmt", "clippy"]


### PR DESCRIPTION
Fixes [FI-1690](https://dfinity.atlassian.net/browse/FI-1690)

Update `now` after an `await` so we don't have decreasing timestamps in the chain of blocks.

This cannot be tested in unit tests because the state machine binary in use does not advance time automatically. Updating the state machine binary is not possible at the moment

Also bumped a bunch of tooling: dfx, GH actions, Rust. Otherwise CI and/or rust-analyzer are unhappy

[FI-1690]: https://dfinity.atlassian.net/browse/FI-1690?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ