### PR TITLE
feat: admin_mint endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 # CHANGELOG
 
 ## [Unreleased] - ReleaseDate
-* Add `admin_mint` endpoint that allows controllers to mint cycles to any account.
+* Add `admin_mint` endpoint that allows controllers to mint cycles to any account without depositing cycles at the same time.
 
 ## [1.0.5] - 2025-06-24
 * Add support for [ICRC-103](https://github.com/dfinity/ICRC/blob/main/ICRCs/ICRC-103/ICRC-103.md).
@@ -44,7 +44,7 @@ No changes to the cycles ledger. Released because a community project relies on 
 
 <!-- next-url -->
 [Unreleased]: https://github.com/dfinity/cycles-ledger/compare/cycles-ledger-v1.0.5...HEAD
-[1.0.4]: https://github.com/dfinity/cycles-ledger/compare/cycles-ledger-v1.0.4...cycles-ledger-v1.0.5
+[1.0.5]: https://github.com/dfinity/cycles-ledger/compare/cycles-ledger-v1.0.4...cycles-ledger-v1.0.5
 [1.0.4]: https://github.com/dfinity/cycles-ledger/compare/cycles-ledger-v1.0.3...cycles-ledger-v1.0.4
 [1.0.3]: https://github.com/dfinity/cycles-ledger/compare/cycles-ledger-v1.0.2...cycles-ledger-v1.0.3
 [1.0.2]: https://github.com/dfinity/cycles-ledger/compare/cycles-ledger-v1.0.1...cycles-ledger-v1.0.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 # CHANGELOG
 
 ## [Unreleased] - ReleaseDate
+* Add `admin_mint` endpoint that allows controllers to mint cycles to any account.
 
 ## [1.0.5] - 2025-06-24
 * Add support for [ICRC-103](https://github.com/dfinity/ICRC/blob/main/ICRCs/ICRC-103/ICRC-103.md).

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@
 
 # This is the "builder", i.e. the base image used later to build the final
 # code.
-FROM --platform=linux/amd64 ubuntu:20.04 as builder
+FROM --platform=linux/amd64 ubuntu:22.04 as builder
 SHELL ["bash", "-c"]
 
 ARG rust_version=1.85.0

--- a/INTERFACE_SPECIFICATION.md
+++ b/INTERFACE_SPECIFICATION.md
@@ -7,6 +7,26 @@ The cycles ledger complies with the [ICRC-1](https://github.com/dfinity/ICRC-1/b
 
 The additional endpoints are presented in the following.
 
+### `admin_mint`
+```
+type Account = record { owner : principal; subaccount : opt vec nat8 };
+
+type BlockIndex = nat;
+
+type AdminMintArg = record {
+  to : Account;
+  memo : opt vec nat8;
+  amount : nat;
+};
+
+type AdminMintResult = record { balance : nat; block_index : BlockIndex };
+
+admin_mint : (AdminMintArg) -> (AdminMintResult);
+```
+
+This endpoint allows the controller of the cycles ledger to mint cycles to any account without depositing cycles at the same time. Only controllers can call this endpoint. There is no fee when admin minting cycles.
+The controller can optionally provide a memo as well. The memo may be at most 32 bytes long.
+
 ### `deposit`
 ```
 type Account = record { owner : principal; subaccount : opt vec nat8 };

--- a/cycles-ledger/cycles-ledger.did
+++ b/cycles-ledger/cycles-ledger.did
@@ -1,4 +1,6 @@
 type Account = record { owner : principal; subaccount : opt vec nat8 };
+type AdminMintArg = record { to : Account; memo : opt blob; amount : nat };
+type AdminMintResult = record { balance : nat; block_index : nat };
 type Allowance = record { allowance : nat; expires_at : opt nat64 };
 type AllowanceArgs = record { account : Account; spender : Account };
 type BlockIndex = nat;
@@ -333,6 +335,7 @@ type ICRC103GetAllowancesResponse = variant {
 };
 
 service : (ledger_args : LedgerArgs) -> {
+  admin_mint : (AdminMintArg) -> (AdminMintResult);
   deposit : (DepositArgs) -> (DepositResult);
   http_request : (HttpRequest) -> (HttpResponse) query;
   icrc1_balance_of : (Account) -> (nat) query;

--- a/cycles-ledger/src/endpoints.rs
+++ b/cycles-ledger/src/endpoints.rs
@@ -55,6 +55,19 @@ pub struct DepositResult {
 }
 
 #[derive(CandidType, Deserialize, Clone, Debug, PartialEq, Eq)]
+pub struct AdminMintArg {
+    pub to: Account,
+    pub amount: Nat,
+    pub memo: Option<Memo>,
+}
+
+#[derive(CandidType, Deserialize, Clone, Debug, PartialEq, Eq)]
+pub struct AdminMintResult {
+    pub block_index: Nat,
+    pub balance: Nat,
+}
+
+#[derive(CandidType, Deserialize, Clone, Debug, PartialEq, Eq)]
 pub struct SupportedStandard {
     pub name: String,
     pub url: String,

--- a/cycles-ledger/src/main.rs
+++ b/cycles-ledger/src/main.rs
@@ -194,6 +194,24 @@ fn deposit(arg: endpoints::DepositArg) -> endpoints::DepositResult {
     }
 }
 
+#[update]
+#[candid_method]
+fn admin_mint(arg: endpoints::AdminMintArg) -> endpoints::AdminMintResult {
+    let caller = ic_cdk::caller();
+    if !ic_cdk::api::is_controller(&caller) {
+        ic_cdk::trap("Only the controller can mint cycles");
+    }
+
+    let amount = arg.amount.0.to_u128().expect("Invalid amount.");
+    match storage::mint(arg.to, amount, arg.memo, ic_cdk::api::time()) {
+        Ok(block_index) => endpoints::AdminMintResult {
+            block_index: Nat::from(block_index),
+            balance: Nat::from(storage::balance_of(&arg.to)),
+        },
+        Err(err) => ic_cdk::trap(&err.to_string()),
+    }
+}
+
 fn execute_transfer(
     from: Account,
     to: Account,

--- a/cycles-ledger/src/main.rs
+++ b/cycles-ledger/src/main.rs
@@ -199,7 +199,7 @@ fn deposit(arg: endpoints::DepositArg) -> endpoints::DepositResult {
 fn admin_mint(arg: endpoints::AdminMintArg) -> endpoints::AdminMintResult {
     let caller = ic_cdk::caller();
     if !ic_cdk::api::is_controller(&caller) {
-        ic_cdk::trap("Only the controller can mint cycles");
+        ic_cdk::trap("Only the controller can admin_mint cycles.");
     }
 
     let amount = arg.amount.0.to_u128().expect("Invalid amount.");

--- a/cycles-ledger/tests/client.rs
+++ b/cycles-ledger/tests/client.rs
@@ -4,9 +4,9 @@ use std::collections::BTreeMap;
 use candid::{CandidType, Decode, Encode, Nat, Principal};
 use cycles_ledger::{
     endpoints::{
-        self, CmcCreateCanisterError, CreateCanisterArgs, CreateCanisterFromArgs,
-        CreateCanisterSuccess, DataCertificate, DepositResult, GetBlocksArg, GetBlocksArgs,
-        GetBlocksResult, WithdrawArgs, WithdrawFromArgs,
+        self, AdminMintArg, AdminMintResult, CmcCreateCanisterError, CreateCanisterArgs,
+        CreateCanisterFromArgs, CreateCanisterSuccess, DataCertificate, DepositResult,
+        GetBlocksArg, GetBlocksArgs, GetBlocksResult, WithdrawArgs, WithdrawFromArgs,
     },
     storage::{Block, CMC_PRINCIPAL},
 };
@@ -92,6 +92,26 @@ pub fn deposit(
         to.owner,
         "deposit",
         DepositArg { cycles, to, memo },
+    )
+}
+
+pub fn admin_mint(
+    env: &StateMachine,
+    cycles_ledger: Principal,
+    to: Account,
+    cycles: u128,
+    memo: Option<Memo>,
+) -> AdminMintResult {
+    update_or_panic(
+        env,
+        cycles_ledger,
+        to.owner,
+        "admin_mint",
+        AdminMintArg {
+            amount: Nat::from(cycles),
+            to,
+            memo,
+        },
     )
 }
 

--- a/cycles-ledger/tests/client.rs
+++ b/cycles-ledger/tests/client.rs
@@ -98,6 +98,7 @@ pub fn deposit(
 pub fn admin_mint(
     env: &StateMachine,
     cycles_ledger: Principal,
+    caller: Principal,
     to: Account,
     cycles: u128,
     memo: Option<Memo>,
@@ -105,7 +106,7 @@ pub fn admin_mint(
     update_or_panic(
         env,
         cycles_ledger,
-        to.owner,
+        caller,
         "admin_mint",
         AdminMintArg {
             amount: Nat::from(cycles),

--- a/cycles-ledger/tests/tests.rs
+++ b/cycles-ledger/tests/tests.rs
@@ -185,7 +185,7 @@ fn get_wasm(name: &'static str) -> Vec<u8> {
 }
 
 fn build_wasm(name: &str) -> Vec<u8> {
-    if name == "cycles-ledgerrr" {
+    if name == "cycles-ledger" {
         let tmp_dir = TempDir::with_prefix("cycles-ledger-tmp-dir").unwrap();
         let cargo_manifest_dir = std::env::var("CARGO_MANIFEST_DIR").unwrap();
         let cargo_manifest_dir = PathBuf::from(cargo_manifest_dir);
@@ -7345,4 +7345,18 @@ fn test_admin_mint_flow_with_caller() {
     let account0 = account(0, None);
 
     env.admin_mint(Some(env.cmc_id), account0, 1_000_000_000, None);
+}
+
+#[test]
+#[should_panic(expected = "memo length exceeds the maximum")]
+fn test_admin_mint_invalid_memo() {
+    let env = TestEnv::setup();
+
+    // Attempt deposit with memo exceeding `MAX_MEMO_LENGTH`. This call should panic.
+    let _res = env.admin_mint(
+        None,
+        account(1, None),
+        10 * FEE,
+        Some(Memo(ByteBuf::from([0; MAX_MEMO_LENGTH as usize + 1]))),
+    );
 }

--- a/cycles-ledger/tests/tests.rs
+++ b/cycles-ledger/tests/tests.rs
@@ -308,6 +308,7 @@ pub fn account(owner: u64, subaccount: Option<u64>) -> Account {
 struct TestEnv {
     pub state_machine: StateMachine,
     pub ledger_id: Principal,
+    #[allow(unused)]
     pub ledger_controller: Principal,
     pub depositor_id: Principal,
     #[allow(dead_code)]
@@ -391,6 +392,7 @@ impl TestEnv {
         client::deposit(&self.state_machine, self.depositor_id, to, amount, memo)
     }
 
+    #[allow(unused)]
     fn admin_mint(&self, to: Account, amount: u128, memo: Option<Memo>) -> AdminMintResult {
         client::admin_mint(&self.state_machine, self.ledger_id, to, amount, memo)
     }

--- a/cycles-ledger/tests/tests.rs
+++ b/cycles-ledger/tests/tests.rs
@@ -7339,7 +7339,7 @@ fn test_admin_mint_flow() {
 }
 
 #[test]
-#[should_panic(expected = "Only the controller can mint cycles")]
+#[should_panic(expected = "Only the controller can admin_mint cycles.")]
 fn test_admin_mint_flow_with_caller() {
     let env = TestEnv::setup();
     let account0 = account(0, None);


### PR DESCRIPTION
Add `admin_mint` endpoint that allows controllers to mint cycles to any account without depositing cycles at the same time.

Also updates the builder image to use `ubuntu-22.04` as base because otherwise dfxvm-init does not work anymore.

Ticket: https://dfinity.atlassian.net/browse/SDK-2226