### PR TITLE
chore: Bump ubuntu from 20.04 to 24.04 in the Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@
 
 # This is the "builder", i.e. the base image used later to build the final
 # code.
-FROM --platform=linux/amd64 ubuntu:20.04 as builder
+FROM --platform=linux/amd64 ubuntu:24.04 as builder
 SHELL ["bash", "-c"]
 
 ARG rust_version=1.85.0


### PR DESCRIPTION
Bump the `ubuntu` version in the `Dockerfile` from `20.04` to `24.04`, since with the old version, building the image fails.