### PR TITLE
feat: specify initial balances

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 # CHANGELOG
 
 ## [Unreleased] - ReleaseDate
+* Add support for `initial_balances` in `InitArgs`. When specifying initial balances it is up to the installer to ensure that the cycles ledger has sufficient cycles available to spend these cycles.
 
 ## [1.0.5] - 2025-06-24
 * Add support for [ICRC-103](https://github.com/dfinity/ICRC/blob/main/ICRCs/ICRC-103/ICRC-103.md).

--- a/cycles-ledger/cycles-ledger.did
+++ b/cycles-ledger/cycles-ledger.did
@@ -179,6 +179,7 @@ type DataCertificate = record {
 type InitArgs = record {
   max_blocks_per_request : nat64;
   index_id : opt principal;
+  initial_balances : opt vec record { Account; nat };
 };
 
 type ChangeIndexId = variant {

--- a/cycles-ledger/src/config.rs
+++ b/cycles-ledger/src/config.rs
@@ -1,5 +1,6 @@
 use candid::{CandidType, Deserialize, Principal};
 use ic_stable_structures::Storable;
+use icrc_ledger_types::icrc1::account::Account;
 use serde::Serialize;
 use std::{borrow::Cow, time::Duration};
 
@@ -29,6 +30,11 @@ pub struct Config {
     /// The principal of the index canister
     /// for this ledger
     pub index_id: Option<Principal>,
+
+    /// The initial balances of the ledger.
+    /// No fee will be charged for minting these initial balances.
+    /// Cycles covering the total initial balances need to be deposited, otherwise unexpected errors may occur.
+    pub initial_balances: Option<Vec<(Account, u128)>>,
 }
 
 impl Default for Config {
@@ -36,6 +42,7 @@ impl Default for Config {
         Self {
             max_blocks_per_request: 100,
             index_id: None,
+            initial_balances: None,
         }
     }
 }
@@ -62,6 +69,7 @@ fn test_config_ser_de() {
     let config = Config {
         max_blocks_per_request: 10,
         index_id: None,
+        initial_balances: None,
     };
     assert_eq!(Config::from_bytes(config.to_bytes()), config);
 }

--- a/cycles-ledger/src/main.rs
+++ b/cycles-ledger/src/main.rs
@@ -34,6 +34,12 @@ fn init(ledger_args: LedgerArgs) {
     match ledger_args {
         LedgerArgs::Init(config) => {
             mutate_state(|state| {
+                if let Some(initial_balances) = config.initial_balances.as_ref() {
+                    for (account, amount) in initial_balances {
+                        storage::mint(*account, *amount, None, ic_cdk::api::time())
+                            .expect("Failed to mint initial balance");
+                    }
+                }
                 state.config.set(config)
                     .expect("Failed to change configuration");
             })

--- a/cycles-ledger/src/main.rs
+++ b/cycles-ledger/src/main.rs
@@ -33,13 +33,13 @@ use num_traits::ToPrimitive;
 fn init(ledger_args: LedgerArgs) {
     match ledger_args {
         LedgerArgs::Init(config) => {
-            mutate_state(|state| {
-                if let Some(initial_balances) = config.initial_balances.as_ref() {
-                    for (account, amount) in initial_balances {
-                        storage::mint(*account, *amount, None, ic_cdk::api::time())
-                            .expect("Failed to mint initial balance");
-                    }
+            if let Some(initial_balances) = config.initial_balances.as_ref() {
+                for (account, amount) in initial_balances {
+                    storage::mint(*account, *amount, None, ic_cdk::api::time())
+                        .expect("Failed to mint initial balance");
                 }
+            }
+            mutate_state(|state| {
                 state.config.set(config)
                     .expect("Failed to change configuration");
             })

--- a/cycles-ledger/tests/tests.rs
+++ b/cycles-ledger/tests/tests.rs
@@ -7202,3 +7202,44 @@ fn test_icrc2_transfer_from_invalid_memo() {
         },
     );
 }
+
+#[test]
+fn test_init_with_initial_balances() {
+    let account1 = account(1, None);
+    let account2 = account(2, None);
+    let account3 = account(3, None);
+    let env = TestEnv::setup_with_ledger_conf(LedgerConfig {
+        initial_balances: Some(vec![
+            (account1, 1_000_000_000),
+            (account2, 2_000_000_000),
+            (account3, 3_000_000_000),
+        ]),
+        ..Default::default()
+    });
+    assert_eq!(env.icrc1_balance_of(account1), 1_000_000_000);
+    assert_eq!(env.icrc1_balance_of(account2), 2_000_000_000);
+    assert_eq!(env.icrc1_balance_of(account3), 3_000_000_000);
+    let block0 = get_block(&env.state_machine, env.ledger_id, Nat::from(0u8));
+    if let Operation::Mint { to, amount, .. } = block0.transaction.operation {
+        assert_eq!(to, account1);
+        assert_eq!(amount, 1_000_000_000);
+    } else {
+        panic!("Expected Mint operation for block 0");
+    }
+
+    let block1 = get_block(&env.state_machine, env.ledger_id, Nat::from(1u8));
+    if let Operation::Mint { to, amount, .. } = block1.transaction.operation {
+        assert_eq!(to, account2);
+        assert_eq!(amount, 2_000_000_000);
+    } else {
+        panic!("Expected Mint operation for block 1");
+    }
+
+    let block2 = get_block(&env.state_machine, env.ledger_id, Nat::from(2u8));
+    if let Operation::Mint { to, amount, .. } = block2.transaction.operation {
+        assert_eq!(to, account3);
+        assert_eq!(amount, 3_000_000_000);
+    } else {
+        panic!("Expected Mint operation for block 2");
+    }
+}

--- a/cycles-ledger/tests/tests.rs
+++ b/cycles-ledger/tests/tests.rs
@@ -5292,6 +5292,7 @@ fn test_get_blocks_max_length() {
     let env = TestEnv::setup_with_ledger_conf(LedgerConfig {
         max_blocks_per_request: MAX_BLOCKS_PER_REQUEST,
         index_id: None,
+        initial_balances: None,
     });
     let fee = env.icrc1_fee();
 


### PR DESCRIPTION
Add support for `initial_balances` in `InitArgs`. When specifying initial balances it is up to the installer to ensure that the cycles ledger has sufficient cycles available to spend these cycles.

https://dfinity.atlassian.net/browse/SDK-2280