### PR TITLE
fix: DEFI-2824: Use canonical ICRC-103 and ICRC-106 document URLs

### DIFF
--- a/cycles-ledger/src/main.rs
+++ b/cycles-ledger/src/main.rs
@@ -115,11 +115,13 @@ fn icrc1_supported_standards() -> Vec<endpoints::SupportedStandard> {
         },
         endpoints::SupportedStandard {
             name: "ICRC-103".to_string(),
-            url: "https://github.com/dfinity/ICRC/tree/main/ICRCs/ICRC-103".to_string(),
+            url: "https://github.com/dfinity/ICRC/blob/main/ICRCs/ICRC-103/ICRC-103.md"
+                .to_string(),
         },
         endpoints::SupportedStandard {
             name: "ICRC-106".to_string(),
-            url: "https://github.com/dfinity/ICRC/pull/106".to_string(),
+            url: "https://github.com/dfinity/ICRC/blob/main/ICRCs/ICRC-106/ICRC-106.md"
+                .to_string(),
         },
     ]
 }

--- a/cycles-ledger/src/main.rs
+++ b/cycles-ledger/src/main.rs
@@ -115,13 +115,11 @@ fn icrc1_supported_standards() -> Vec<endpoints::SupportedStandard> {
         },
         endpoints::SupportedStandard {
             name: "ICRC-103".to_string(),
-            url: "https://github.com/dfinity/ICRC/blob/main/ICRCs/ICRC-103/ICRC-103.md"
-                .to_string(),
+            url: "https://github.com/dfinity/ICRC/blob/main/ICRCs/ICRC-103/ICRC-103.md".to_string(),
         },
         endpoints::SupportedStandard {
             name: "ICRC-106".to_string(),
-            url: "https://github.com/dfinity/ICRC/blob/main/ICRCs/ICRC-106/ICRC-106.md"
-                .to_string(),
+            url: "https://github.com/dfinity/ICRC/blob/main/ICRCs/ICRC-106/ICRC-106.md".to_string(),
         },
     ]
 }


### PR DESCRIPTION
## Summary
- Fix the URL for `ICRC-103` in `icrc1_supported_standards` — was a `tree/` directory listing, now points to the `blob/main/ICRCs/ICRC-103/ICRC-103.md` document.
- Fix the URL for `ICRC-106` similarly — was a link to the originating PR (`dfinity/ICRC#106`), now points to the `blob/main/ICRCs/ICRC-106/ICRC-106.md` document.

Addresses the review comment from @marc0olo on #178 and the related branch ticket DEFI-2824.

🤖 Generated with [Claude Code](https://claude.com/claude-code)