### PR TITLE
fix: align test_supported_standards expectations with canonical ICRC URLs

### DIFF
--- a/cycles-ledger/tests/tests.rs
+++ b/cycles-ledger/tests/tests.rs
@@ -7875,11 +7875,11 @@ fn expected_supported_standards() -> Vec<SupportedStandard> {
         },
         SupportedStandard {
             name: "ICRC-103".to_string(),
-            url: "https://github.com/dfinity/ICRC/tree/main/ICRCs/ICRC-103".to_string(),
+            url: "https://github.com/dfinity/ICRC/blob/main/ICRCs/ICRC-103/ICRC-103.md".to_string(),
         },
         SupportedStandard {
             name: "ICRC-106".to_string(),
-            url: "https://github.com/dfinity/ICRC/pull/106".to_string(),
+            url: "https://github.com/dfinity/ICRC/blob/main/ICRCs/ICRC-106/ICRC-106.md".to_string(),
         },
     ]
 }


### PR DESCRIPTION
`main` has been red since #179 merged. Any PR opened since then fails `build (9.0.2)` / "Check and Test" on `test_supported_standards` — for example [#177](https://github.com/dfinity/cycles-ledger/pull/177), which is an unrelated `rustls-webpki` dependabot bump:

```
assertion `left == right` failed: icrc1_supported_standards URL mismatch for ICRC-103
  left:  "https://github.com/dfinity/ICRC/blob/main/ICRCs/ICRC-103/ICRC-103.md"   (canister)
  right: "https://github.com/dfinity/ICRC/tree/main/ICRCs/ICRC-103"               (test)
```

## Root cause

A semantic merge conflict between two PRs that never conflicted textually:

| Commit | Change |
| --- | --- |
| `ddc0bbf` (#178, ICRC-10) | Added `expected_supported_standards()` to `tests.rs` with the then-current URLs (`tree/…/ICRC-103`, `pull/106`) |
| `7429361` (#179, canonical URLs) | Changed **only** `src/main.rs` to `blob/…/ICRC-103.md` and `blob/…/ICRC-106.md` |

#179 was branched from `301bae3`, before #178 landed, so the test did not exist on its base and its CI went green. It then merged on top of #178, leaving the source and the test disagreeing.

Nothing caught it afterwards because "Check and Test" only runs on `pull_request` — the recent `main` runs are all "Dependabot Updates".

## Fix

Update the two stale expectations to match `src/main.rs`. ICRC-106 was stale for the same reason; the assertion loop just panicked on ICRC-103 first. All six entries now match the source exactly.

## Follow-up worth considering

Adding `push: branches: [main]` to the "Check and Test" workflow, so a red `main` surfaces immediately rather than via the next unlucky dependabot PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
